### PR TITLE
修复XML序列化命名空间问题

### DIFF
--- a/BannerlordModEditor.Common.Tests/GameTests.cs
+++ b/BannerlordModEditor.Common.Tests/GameTests.cs
@@ -49,7 +49,9 @@ namespace BannerlordModEditor.Common.Tests
                     OmitXmlDeclaration = false
                 }))
                 {
-                    serializer.Serialize(xmlWriter, itemModifiers);
+                    var ns = new XmlSerializerNamespaces();
+                    ns.Add("", "");
+                    serializer.Serialize(xmlWriter, itemModifiers, ns);
                 }
                 savedXml = writer.ToString();
             }

--- a/BannerlordModEditor.Common.Tests/MovementSetsXmlTests.cs
+++ b/BannerlordModEditor.Common.Tests/MovementSetsXmlTests.cs
@@ -40,7 +40,9 @@ namespace BannerlordModEditor.Common.Tests
                     OmitXmlDeclaration = false
                 }))
                 {
-                    serializer.Serialize(xmlWriter, movementSets);
+                    var ns = new XmlSerializerNamespaces();
+                    ns.Add("", "");
+                    serializer.Serialize(xmlWriter, movementSets, ns);
                 }
                 savedXml = writer.ToString();
             }

--- a/BannerlordModEditor.Common.Tests/Services/XmlTestUtils.cs
+++ b/BannerlordModEditor.Common.Tests/Services/XmlTestUtils.cs
@@ -26,7 +26,9 @@ namespace BannerlordModEditor.Common.Tests.Services
             };
             using var sw = new Utf8StringWriter();
             using var writer = XmlWriter.Create(sw, settings);
-            serializer.Serialize(writer, obj);
+            var ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+            serializer.Serialize(writer, obj, ns);
             return sw.ToString();
         }
 

--- a/BannerlordModEditor.Common.Tests/TestData/SourceFiles/banner_icons.xml
+++ b/BannerlordModEditor.Common.Tests/TestData/SourceFiles/banner_icons.xml
@@ -1,0 +1,1765 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<base xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	type="string">
+	<BannerIconData>
+		<BannerIconGroup
+			id="1"
+			name="{=str_banner_editor_background}Background"
+			is_pattern="true">
+			<Background
+				id="1"
+				mesh_name="banner_background_test_1" />
+			<Background
+				id="2"
+				mesh_name="banner_background_test_2" />
+			<Background
+				id="3"
+				mesh_name="banner_background_test_3" />
+			<Background
+				id="4"
+				mesh_name="banner_background_test_4" />
+			<Background
+				id="5"
+				mesh_name="banner_background_test_5" />
+			<Background
+				id="6"
+				mesh_name="banner_background_test_6" />
+			<Background
+				id="7"
+				mesh_name="banner_background_test_7" />
+			<Background
+				id="8"
+				mesh_name="banner_background_test_8" />
+			<Background
+				id="9"
+				mesh_name="banner_background_test_9" />
+			<Background
+				id="10"
+				mesh_name="banner_background_test_10" />
+			<Background
+				id="11"
+				mesh_name="banner_background_test_11"
+				is_base_background="true" />
+			<Background
+				id="12"
+				mesh_name="banner_background_test_12" />
+			<Background
+				id="13"
+				mesh_name="banner_background_test_13" />
+			<Background
+				id="14"
+				mesh_name="banner_background_test_14" />
+			<Background
+				id="15"
+				mesh_name="banner_background_test_15" />
+			<Background
+				id="16"
+				mesh_name="banner_background_test_16" />
+			<Background
+				id="17"
+				mesh_name="banner_background_test_17" />
+			<Background
+				id="18"
+				mesh_name="banner_background_test_18" />
+			<Background
+				id="19"
+				mesh_name="banner_background_test_19" />
+			<Background
+				id="20"
+				mesh_name="banner_background_test_20" />
+			<Background
+				id="21"
+				mesh_name="banner_background_test_21" />
+			<Background
+				id="22"
+				mesh_name="banner_background_test_22" />
+			<Background
+				id="23"
+				mesh_name="banner_background_test_23" />
+			<Background
+				id="24"
+				mesh_name="banner_background_test_24" />
+			<Background
+				id="25"
+				mesh_name="banner_background_test_25" />
+			<Background
+				id="26"
+				mesh_name="banner_background_test_26" />
+			<Background
+				id="27"
+				mesh_name="banner_background_test_27" />
+			<Background
+				id="28"
+				mesh_name="banner_background_test_28" />
+			<Background
+				id="29"
+				mesh_name="banner_background_test_29" />
+			<Background
+				id="30"
+				mesh_name="banner_background_test_30" />
+			<Background
+				id="31"
+				mesh_name="banner_background_test_31" />
+			<Background
+				id="32"
+				mesh_name="banner_background_test_32" />
+			<Background
+				id="33"
+				mesh_name="banner_background_test_33" />
+			<Background
+				id="34"
+				mesh_name="banner_background_test_34" />
+			<Background
+				id="35"
+				mesh_name="banner_background_test_35" />
+			<Background
+				id="36"
+				mesh_name="banner_background_test_36" />
+		</BannerIconGroup>
+		<BannerIconGroup
+			id="2"
+			name="{=str_banner_editor_animal}Animal"
+			is_pattern="false">
+			<Icon
+				id="100"
+				material_name="custom_banner_icons_01"
+				texture_index="10" />
+			<Icon
+				id="101"
+				material_name="custom_banner_icons_01"
+				texture_index="9" />
+			<Icon
+				id="102"
+				material_name="custom_banner_icons_01"
+				texture_index="3" />
+			<Icon
+				id="103"
+				material_name="custom_banner_icons_01"
+				texture_index="11" />
+			<Icon
+				id="104"
+				material_name="custom_banner_icons_02"
+				texture_index="4" />
+			<Icon
+				id="105"
+				material_name="custom_banner_icons_04"
+				texture_index="13" />
+			<Icon
+				id="106"
+				material_name="custom_banner_icons_02"
+				texture_index="1" />
+			<Icon
+				id="107"
+				material_name="custom_banner_icons_03"
+				texture_index="6" />
+			<Icon
+				id="108"
+				material_name="custom_banner_icons_02"
+				texture_index="6" />
+			<Icon
+				id="109"
+				material_name="custom_banner_icons_03"
+				texture_index="12" />
+			<Icon
+				id="110"
+				material_name="custom_banner_icons_02"
+				texture_index="8" />
+			<Icon
+				id="111"
+				material_name="custom_banner_icons_02"
+				texture_index="5" />
+			<Icon
+				id="112"
+				material_name="custom_banner_icons_04"
+				texture_index="5" />
+			<Icon
+				id="113"
+				material_name="custom_banner_icons_02"
+				texture_index="15" />
+			<Icon
+				id="114"
+				material_name="custom_banner_icons_03"
+				texture_index="13" />
+			<Icon
+				id="115"
+				material_name="custom_banner_icons_02"
+				texture_index="2" />
+			<Icon
+				id="116"
+				material_name="custom_banner_icons_04"
+				texture_index="7" />
+			<Icon
+				id="117"
+				material_name="custom_banner_icons_04"
+				texture_index="0" />
+			<Icon
+				id="118"
+				material_name="custom_banner_icons_02"
+				texture_index="0" />
+			<Icon
+				id="119"
+				material_name="custom_banner_icons_04"
+				texture_index="6" />
+			<Icon
+				id="120"
+				material_name="custom_banner_icons_04"
+				texture_index="11" />
+			<Icon
+				id="121"
+				material_name="custom_banner_icons_04"
+				texture_index="3" />
+			<Icon
+				id="122"
+				material_name="custom_banner_icons_02"
+				texture_index="13" />
+			<Icon
+				id="123"
+				material_name="custom_banner_icons_04"
+				texture_index="8" />
+			<Icon
+				id="124"
+				material_name="custom_banner_icons_01"
+				texture_index="8" />
+			<Icon
+				id="125"
+				material_name="custom_banner_icons_01"
+				texture_index="1" />
+			<Icon
+				id="126"
+				material_name="custom_banner_icons_03"
+				texture_index="10" />
+			<Icon
+				id="127"
+				material_name="custom_banner_icons_02"
+				texture_index="11" />
+			<Icon
+				id="128"
+				material_name="custom_banner_icons_01"
+				texture_index="12" />
+			<Icon
+				id="129"
+				material_name="custom_banner_icons_03"
+				texture_index="3" />
+			<Icon
+				id="130"
+				material_name="custom_banner_icons_03"
+				texture_index="4" />
+			<Icon
+				id="131"
+				material_name="custom_banner_icons_02"
+				texture_index="12" />
+			<Icon
+				id="132"
+				material_name="custom_banner_icons_02"
+				texture_index="9" />
+			<Icon
+				id="133"
+				material_name="custom_banner_icons_02"
+				texture_index="7" />
+			<Icon
+				id="134"
+				material_name="custom_banner_icons_04"
+				texture_index="4" />
+			<Icon
+				id="135"
+				material_name="custom_banner_icons_03"
+				texture_index="11" />
+			<Icon
+				id="136"
+				material_name="custom_banner_icons_04"
+				texture_index="2" />
+			<Icon
+				id="137"
+				material_name="custom_banner_icons_01"
+				texture_index="6" />
+			<Icon
+				id="138"
+				material_name="custom_banner_icons_01"
+				texture_index="0" />
+			<Icon
+				id="139"
+				material_name="custom_banner_icons_04"
+				texture_index="1" />
+			<Icon
+				id="140"
+				material_name="custom_banner_icons_01"
+				texture_index="5" />
+			<Icon
+				id="141"
+				material_name="custom_banner_icons_01"
+				texture_index="4" />
+			<Icon
+				id="142"
+				material_name="custom_banner_icons_04"
+				texture_index="14" />
+			<Icon
+				id="143"
+				material_name="custom_banner_icons_02"
+				texture_index="14" />
+			<Icon
+				id="144"
+				material_name="custom_banner_icons_04"
+				texture_index="15" />
+			<Icon
+				id="145"
+				material_name="custom_banner_icons_03"
+				texture_index="2" />
+			<Icon
+				id="146"
+				material_name="custom_banner_icons_04"
+				texture_index="12" />
+			<Icon
+				id="147"
+				material_name="custom_banner_icons_03"
+				texture_index="7" />
+			<Icon
+				id="148"
+				material_name="custom_banner_icons_03"
+				texture_index="8" />
+			<Icon
+				id="149"
+				material_name="custom_banner_icons_01"
+				texture_index="2" />
+			<Icon
+				id="150"
+				material_name="custom_banner_icons_03"
+				texture_index="15" />
+			<Icon
+				id="151"
+				material_name="custom_banner_icons_03"
+				texture_index="1" />
+			<Icon
+				id="152"
+				material_name="custom_banner_icons_02"
+				texture_index="10" />
+			<Icon
+				id="153"
+				material_name="custom_banner_icons_03"
+				texture_index="5" />
+			<Icon
+				id="154"
+				material_name="custom_banner_icons_03"
+				texture_index="0" />
+			<Icon
+				id="155"
+				material_name="custom_banner_icons_01"
+				texture_index="14" />
+			<Icon
+				id="156"
+				material_name="custom_banner_icons_02"
+				texture_index="3" />
+			<Icon
+				id="157"
+				material_name="custom_banner_icons_01"
+				texture_index="7" />
+			<Icon
+				id="158"
+				material_name="custom_banner_icons_01"
+				texture_index="13" />
+			<Icon
+				id="159"
+				material_name="custom_banner_icons_03"
+				texture_index="14" />
+			<!--vlandia-->
+			<Icon
+				id="160"
+				material_name="custom_banner_icons_15"
+				texture_index="7"
+				is_reserved="true" />
+			<!--normal empire eagle-->
+			<Icon
+				id="161"
+				material_name="custom_banner_icons_15"
+				texture_index="10"
+				is_reserved="true" />
+			<!--southern empire-->
+			<Icon
+				id="162"
+				material_name="custom_banner_icons_15"
+				texture_index="11"
+				is_reserved="true" />
+			<!--north empire-->
+			<Icon
+				id="163"
+				material_name="custom_banner_icons_15"
+				texture_index="12"
+				is_reserved="true" />
+			<!--western empire-->
+			<Icon
+				id="164"
+				material_name="custom_banner_icons_15"
+				texture_index="13"
+				is_reserved="true" />
+		</BannerIconGroup>
+		<BannerIconGroup
+			id="3"
+			name="{=str_bannereditor_flora}Flora"
+			is_pattern="false">
+			<Icon
+				id="200"
+				material_name="custom_banner_icons_13"
+				texture_index="0" />
+			<Icon
+				id="201"
+				material_name="custom_banner_icons_05"
+				texture_index="14" />
+			<Icon
+				id="202"
+				material_name="custom_banner_icons_05"
+				texture_index="13" />
+			<Icon
+				id="203"
+				material_name="custom_banner_icons_05"
+				texture_index="6" />
+			<Icon
+				id="204"
+				material_name="custom_banner_icons_05"
+				texture_index="9" />
+			<Icon
+				id="205"
+				material_name="custom_banner_icons_05"
+				texture_index="0" />
+			<Icon
+				id="206"
+				material_name="custom_banner_icons_05"
+				texture_index="1" />
+			<Icon
+				id="207"
+				material_name="custom_banner_icons_05"
+				texture_index="3" />
+			<Icon
+				id="208"
+				material_name="custom_banner_icons_05"
+				texture_index="15" />
+			<Icon
+				id="209"
+				material_name="custom_banner_icons_05"
+				texture_index="5" />
+			<Icon
+				id="210"
+				material_name="custom_banner_icons_13"
+				texture_index="3" />
+			<Icon
+				id="211"
+				material_name="custom_banner_icons_13"
+				texture_index="8" />
+			<Icon
+				id="212"
+				material_name="custom_banner_icons_13"
+				texture_index="2" />
+			<Icon
+				id="213"
+				material_name="custom_banner_icons_13"
+				texture_index="1" />
+			<Icon
+				id="214"
+				material_name="custom_banner_icons_13"
+				texture_index="6" />
+			<Icon
+				id="215"
+				material_name="custom_banner_icons_13"
+				texture_index="7" />
+			<Icon
+				id="216"
+				material_name="custom_banner_icons_13"
+				texture_index="4" />
+			<Icon
+				id="217"
+				material_name="custom_banner_icons_13"
+				texture_index="5" />
+			<Icon
+				id="218"
+				material_name="custom_banner_icons_05"
+				texture_index="11" />
+			<Icon
+				id="219"
+				material_name="custom_banner_icons_05"
+				texture_index="2" />
+			<Icon
+				id="220"
+				material_name="custom_banner_icons_05"
+				texture_index="4" />
+			<Icon
+				id="221"
+				material_name="custom_banner_icons_05"
+				texture_index="10" />
+			<Icon
+				id="222"
+				material_name="custom_banner_icons_05"
+				texture_index="7" />
+			<Icon
+				id="223"
+				material_name="custom_banner_icons_05"
+				texture_index="8" />
+		</BannerIconGroup>
+		<BannerIconGroup
+			id="4"
+			name="{=str_banner_editor_handmade}Handmade"
+			is_pattern="false">
+			<Icon
+				id="300"
+				material_name="custom_banner_icons_13"
+				texture_index="13" />
+			<Icon
+				id="301"
+				material_name="custom_banner_icons_06"
+				texture_index="13" />
+			<Icon
+				id="302"
+				material_name="custom_banner_icons_06"
+				texture_index="11" />
+			<Icon
+				id="303"
+				material_name="custom_banner_icons_06"
+				texture_index="2" />
+			<Icon
+				id="304"
+				material_name="custom_banner_icons_06"
+				texture_index="3" />
+			<Icon
+				id="306"
+				material_name="custom_banner_icons_06"
+				texture_index="0" />
+			<Icon
+				id="305"
+				material_name="custom_banner_icons_06"
+				texture_index="15" />
+			<Icon
+				id="307"
+				material_name="custom_banner_icons_06"
+				texture_index="9" />
+			<Icon
+				id="308"
+				material_name="custom_banner_icons_06"
+				texture_index="1" />
+			<Icon
+				id="309"
+				material_name="custom_banner_icons_06"
+				texture_index="7" />
+			<Icon
+				id="310"
+				material_name="custom_banner_icons_06"
+				texture_index="14" />
+			<Icon
+				id="311"
+				material_name="custom_banner_icons_06"
+				texture_index="10" />
+			<Icon
+				id="312"
+				material_name="custom_banner_icons_06"
+				texture_index="5" />
+			<Icon
+				id="313"
+				material_name="custom_banner_icons_06"
+				texture_index="12" />
+			<Icon
+				id="314"
+				material_name="custom_banner_icons_06"
+				texture_index="4" />
+			<Icon
+				id="315"
+				material_name="custom_banner_icons_06"
+				texture_index="6" />
+			<Icon
+				id="316"
+				material_name="custom_banner_icons_07"
+				texture_index="0" />
+			<Icon
+				id="317"
+				material_name="custom_banner_icons_07"
+				texture_index="1" />
+			<Icon
+				id="318"
+				material_name="custom_banner_icons_07"
+				texture_index="2" />
+			<Icon
+				id="319"
+				material_name="custom_banner_icons_07"
+				texture_index="3" />
+			<Icon
+				id="320"
+				material_name="custom_banner_icons_07"
+				texture_index="4" />
+			<Icon
+				id="321"
+				material_name="custom_banner_icons_07"
+				texture_index="8" />
+			<Icon
+				id="322"
+				material_name="custom_banner_icons_12"
+				texture_index="8" />
+			<Icon
+				id="323"
+				material_name="custom_banner_icons_12"
+				texture_index="13" />
+			<Icon
+				id="324"
+				material_name="custom_banner_icons_14"
+				texture_index="1" />
+			<Icon
+				id="325"
+				material_name="custom_banner_icons_07"
+				texture_index="15" />
+			<Icon
+				id="326"
+				material_name="custom_banner_icons_07"
+				texture_index="13" />
+			<Icon
+				id="327"
+				material_name="custom_banner_icons_07"
+				texture_index="12" />
+			<Icon
+				id="328"
+				material_name="custom_banner_icons_07"
+				texture_index="14" />
+			<Icon
+				id="329"
+				material_name="custom_banner_icons_14"
+				texture_index="0" />
+			<Icon
+				id="330"
+				material_name="custom_banner_icons_13"
+				texture_index="9" />
+			<Icon
+				id="331"
+				material_name="custom_banner_icons_13"
+				texture_index="11" />
+			<Icon
+				id="332"
+				material_name="custom_banner_icons_13"
+				texture_index="15" />
+			<Icon
+				id="333"
+				material_name="custom_banner_icons_13"
+				texture_index="10" />
+			<Icon
+				id="334"
+				material_name="custom_banner_icons_07"
+				texture_index="9" />
+			<Icon
+				id="335"
+				material_name="custom_banner_icons_11"
+				texture_index="2" />
+			<Icon
+				id="336"
+				material_name="custom_banner_icons_07"
+				texture_index="6" />
+			<Icon
+				id="337"
+				material_name="custom_banner_icons_07"
+				texture_index="7" />
+			<Icon
+				id="338"
+				material_name="custom_banner_icons_13"
+				texture_index="12" />
+			<Icon
+				id="339"
+				material_name="custom_banner_icons_13"
+				texture_index="14" />
+			<Icon
+				id="340"
+				material_name="custom_banner_icons_07"
+				texture_index="5" />
+			<Icon
+				id="341"
+				material_name="custom_banner_icons_08"
+				texture_index="11" />
+			<Icon
+				id="342"
+				material_name="custom_banner_icons_10"
+				texture_index="13" />
+			<Icon
+				id="343"
+				material_name="custom_banner_icons_08"
+				texture_index="10" />
+			<Icon
+				id="344"
+				material_name="custom_banner_icons_12"
+				texture_index="14" />
+			<Icon
+				id="345"
+				material_name="custom_banner_icons_07"
+				texture_index="10" />
+			<Icon
+				id="346"
+				material_name="custom_banner_icons_07"
+				texture_index="11" />
+			<Icon
+				id="347"
+				material_name="custom_banner_icons_15"
+				texture_index="4" />
+		</BannerIconGroup>
+		<BannerIconGroup
+			id="5"
+			name="{=str_banner_editor_sign}Sign"
+			is_pattern="false">
+			<Icon
+				id="400"
+				material_name="custom_banner_icons_11"
+				texture_index="11" />
+			<Icon
+				id="401"
+				material_name="custom_banner_icons_11"
+				texture_index="15" />
+			<Icon
+				id="402"
+				material_name="custom_banner_icons_09"
+				texture_index="11" />
+			<Icon
+				id="403"
+				material_name="custom_banner_icons_09"
+				texture_index="10" />
+			<Icon
+				id="404"
+				material_name="custom_banner_icons_08"
+				texture_index="8" />
+			<Icon
+				id="405"
+				material_name="custom_banner_icons_08"
+				texture_index="0" />
+			<Icon
+				id="406"
+				material_name="custom_banner_icons_08"
+				texture_index="3" />
+			<Icon
+				id="407"
+				material_name="custom_banner_icons_08"
+				texture_index="5" />
+			<Icon
+				id="408"
+				material_name="custom_banner_icons_08"
+				texture_index="7" />
+			<Icon
+				id="409"
+				material_name="custom_banner_icons_09"
+				texture_index="0" />
+			<Icon
+				id="410"
+				material_name="custom_banner_icons_09"
+				texture_index="9" />
+			<Icon
+				id="411"
+				material_name="custom_banner_icons_11"
+				texture_index="3" />
+			<Icon
+				id="412"
+				material_name="custom_banner_icons_10"
+				texture_index="8" />
+			<Icon
+				id="413"
+				material_name="custom_banner_icons_08"
+				texture_index="6" />
+			<Icon
+				id="414"
+				material_name="custom_banner_icons_09"
+				texture_index="3" />
+			<Icon
+				id="415"
+				material_name="custom_banner_icons_08"
+				texture_index="15" />
+			<Icon
+				id="416"
+				material_name="custom_banner_icons_09"
+				texture_index="4" />
+			<Icon
+				id="417"
+				material_name="custom_banner_icons_08"
+				texture_index="13" />
+			<Icon
+				id="418"
+				material_name="custom_banner_icons_08"
+				texture_index="12" />
+			<Icon
+				id="419"
+				material_name="custom_banner_icons_10"
+				texture_index="11" />
+			<Icon
+				id="420"
+				material_name="custom_banner_icons_01"
+				texture_index="15" />
+			<Icon
+				id="421"
+				material_name="custom_banner_icons_11"
+				texture_index="4" />
+			<Icon
+				id="422"
+				material_name="custom_banner_icons_08"
+				texture_index="14" />
+			<Icon
+				id="423"
+				material_name="custom_banner_icons_12"
+				texture_index="12" />
+			<Icon
+				id="424"
+				material_name="custom_banner_icons_11"
+				texture_index="9" />
+			<Icon
+				id="425"
+				material_name="custom_banner_icons_11"
+				texture_index="0" />
+			<Icon
+				id="426"
+				material_name="custom_banner_icons_10"
+				texture_index="0" />
+			<Icon
+				id="427"
+				material_name="custom_banner_icons_10"
+				texture_index="12" />
+			<Icon
+				id="428"
+				material_name="custom_banner_icons_10"
+				texture_index="10" />
+			<Icon
+				id="429"
+				material_name="custom_banner_icons_10"
+				texture_index="3" />
+			<Icon
+				id="430"
+				material_name="custom_banner_icons_10"
+				texture_index="4" />
+			<Icon
+				id="431"
+				material_name="custom_banner_icons_09"
+				texture_index="1" />
+			<Icon
+				id="432"
+				material_name="custom_banner_icons_03"
+				texture_index="9" />
+			<Icon
+				id="433"
+				material_name="custom_banner_icons_04"
+				texture_index="10" />
+			<Icon
+				id="434"
+				material_name="custom_banner_icons_04"
+				texture_index="9" />
+			<Icon
+				id="435"
+				material_name="custom_banner_icons_09"
+				texture_index="13" />
+			<Icon
+				id="436"
+				material_name="custom_banner_icons_09"
+				texture_index="12" />
+			<Icon
+				id="437"
+				material_name="custom_banner_icons_08"
+				texture_index="9" />
+			<Icon
+				id="438"
+				material_name="custom_banner_icons_09"
+				texture_index="7" />
+			<Icon
+				id="439"
+				material_name="custom_banner_icons_11"
+				texture_index="14" />
+			<Icon
+				id="440"
+				material_name="custom_banner_icons_05"
+				texture_index="12" />
+			<Icon
+				id="441"
+				material_name="custom_banner_icons_08"
+				texture_index="2" />
+			<Icon
+				id="442"
+				material_name="custom_banner_icons_08"
+				texture_index="4" />
+			<Icon
+				id="443"
+				material_name="custom_banner_icons_12"
+				texture_index="15" />
+			<Icon
+				id="444"
+				material_name="custom_banner_icons_08"
+				texture_index="1" />
+			<Icon
+				id="445"
+				material_name="custom_banner_icons_06"
+				texture_index="8" />
+			<Icon
+				id="446"
+				material_name="custom_banner_icons_09"
+				texture_index="15" />
+			<Icon
+				id="448"
+				material_name="custom_banner_icons_09"
+				texture_index="2" />
+			<Icon
+				id="447"
+				material_name="custom_banner_icons_10"
+				texture_index="2" />
+			<Icon
+				id="449"
+				material_name="custom_banner_icons_11"
+				texture_index="1" />
+			<Icon
+				id="450"
+				material_name="custom_banner_icons_10"
+				texture_index="5" />
+			<Icon
+				id="451"
+				material_name="custom_banner_icons_09"
+				texture_index="5" />
+			<Icon
+				id="452"
+				material_name="custom_banner_icons_09"
+				texture_index="6" />
+			<Icon
+				id="453"
+				material_name="custom_banner_icons_10"
+				texture_index="6" />
+			<Icon
+				id="454"
+				material_name="custom_banner_icons_09"
+				texture_index="8" />
+			<Icon
+				id="455"
+				material_name="custom_banner_icons_10"
+				texture_index="7" />
+			<Icon
+				id="456"
+				material_name="custom_banner_icons_09"
+				texture_index="14" />
+			<Icon
+				id="457"
+				material_name="custom_banner_icons_12"
+				texture_index="10" />
+			<Icon
+				id="458"
+				material_name="custom_banner_icons_12"
+				texture_index="11" />
+			<Icon
+				id="459"
+				material_name="custom_banner_icons_12"
+				texture_index="3" />
+			<!--battania-->
+			<Icon
+				id="460"
+				material_name="custom_banner_icons_15"
+				texture_index="9"
+				is_reserved="true" />
+			<!--khuzait-->
+			<Icon
+				id="461"
+				material_name="custom_banner_icons_15"
+				texture_index="14"
+				is_reserved="true" />
+			<!--sturgia-->
+			<Icon
+				id="462"
+				material_name="custom_banner_icons_15"
+				texture_index="15"
+				is_reserved="true" />
+			<!--aserai-->
+			<Icon
+				id="463"
+				material_name="custom_banner_icons_15"
+				texture_index="8"
+				is_reserved="true" />
+		</BannerIconGroup>
+		<BannerIconGroup
+			id="6"
+			name="{=str_banner_editor_shape}Shape"
+			is_pattern="false">
+			<Icon
+				id="500"
+				material_name="custom_banner_icons_11"
+				texture_index="5" />
+			<Icon
+				id="501"
+				material_name="custom_banner_icons_11"
+				texture_index="6" />
+			<Icon
+				id="502"
+				material_name="custom_banner_icons_11"
+				texture_index="7" />
+			<Icon
+				id="503"
+				material_name="custom_banner_icons_14"
+				texture_index="4" />
+			<Icon
+				id="504"
+				material_name="custom_banner_icons_14"
+				texture_index="5" />
+			<Icon
+				id="505"
+				material_name="custom_banner_icons_14"
+				texture_index="6" />
+			<Icon
+				id="506"
+				material_name="custom_banner_icons_14"
+				texture_index="7" />
+			<Icon
+				id="507"
+				material_name="custom_banner_icons_14"
+				texture_index="9" />
+			<Icon
+				id="508"
+				material_name="custom_banner_icons_14"
+				texture_index="10" />
+			<Icon
+				id="509"
+				material_name="custom_banner_icons_14"
+				texture_index="11" />
+			<Icon
+				id="510"
+				material_name="custom_banner_icons_14"
+				texture_index="12" />
+			<Icon
+				id="511"
+				material_name="custom_banner_icons_14"
+				texture_index="13" />
+			<Icon
+				id="512"
+				material_name="custom_banner_icons_11"
+				texture_index="8" />
+			<Icon
+				id="513"
+				material_name="custom_banner_icons_10"
+				texture_index="9" />
+			<Icon
+				id="514"
+				material_name="custom_banner_icons_11"
+				texture_index="10" />
+			<Icon
+				id="515"
+				material_name="custom_banner_icons_14"
+				texture_index="2" />
+			<Icon
+				id="516"
+				material_name="custom_banner_icons_10"
+				texture_index="14" />
+			<Icon
+				id="517"
+				material_name="custom_banner_icons_14"
+				texture_index="8" />
+			<Icon
+				id="518"
+				material_name="custom_banner_icons_11"
+				texture_index="13" />
+			<Icon
+				id="519"
+				material_name="custom_banner_icons_10"
+				texture_index="15" />
+			<Icon
+				id="520"
+				material_name="custom_banner_icons_11"
+				texture_index="12" />
+			<Icon
+				id="521"
+				material_name="custom_banner_icons_14"
+				texture_index="3" />
+			<Icon
+				id="522"
+				material_name="custom_banner_icons_12"
+				texture_index="7" />
+			<Icon
+				id="523"
+				material_name="custom_banner_icons_12"
+				texture_index="0" />
+			<Icon
+				id="524"
+				material_name="custom_banner_icons_12"
+				texture_index="9" />
+			<Icon
+				id="525"
+				material_name="custom_banner_icons_12"
+				texture_index="2" />
+			<Icon
+				id="526"
+				material_name="custom_banner_icons_12"
+				texture_index="1" />
+			<Icon
+				id="527"
+				material_name="custom_banner_icons_12"
+				texture_index="5" />
+			<Icon
+				id="528"
+				material_name="custom_banner_icons_12"
+				texture_index="4" />
+			<Icon
+				id="529"
+				material_name="custom_banner_icons_12"
+				texture_index="6" />
+			<Icon
+				id="530"
+				material_name="custom_banner_icons_15"
+				texture_index="0" />
+			<Icon
+				id="531"
+				material_name="custom_banner_icons_15"
+				texture_index="3" />
+			<Icon
+				id="532"
+				material_name="custom_banner_icons_15"
+				texture_index="1" />
+			<Icon
+				id="533"
+				material_name="custom_banner_icons_15"
+				texture_index="2" />
+			<Icon
+				id="534"
+				material_name="custom_banner_icons_14"
+				texture_index="14" />
+			<Icon
+				id="535"
+				material_name="custom_banner_icons_14"
+				texture_index="15" />
+		</BannerIconGroup>
+		<BannerColors>
+			<!--Aserai background-->
+			<Color
+				id="0"
+				hex="0xffB57A1E" />
+			<!--Aserai color 2-->
+			<Color
+				id="1"
+				hex="0xff4E1A13" />
+			<!--battania background-->
+			<Color
+				id="2"
+				hex="0xff284E19" />
+			<!-- battania color 2-->
+			<Color
+				id="3"
+				hex="0xffB4F0F1" />
+			<!--northern empire background-->
+			<Color
+				id="4"
+				hex="0xff793191" />
+			<!--northern empire color 2-->
+			<Color
+				id="5"
+				hex="0xffFCDE90" />
+			<!--southern background-->
+			<Color
+				id="6"
+				hex="0xff382188" />
+			<!--southern empire color 2-->
+			<Color
+				id="7"
+				hex="0xffDEA940" />
+			<!--western background-->
+			<Color
+				id="8"
+				hex="0xff591645" />
+			<!--western empire color 2-->
+			<Color
+				id="9"
+				hex="0xffFFAD54" />
+			<!--khuzait background-->
+			<Color
+				id="10"
+				hex="0xff429081" />
+			<!--khuzait color 2-->
+			<Color
+				id="11"
+				hex="0xffEFC990" />
+			<!--sturgia background-->
+			<Color
+				id="12"
+				hex="0xff224277" />
+			<!--sturgia color 2-f-->
+			<Color
+				id="13"
+				hex="0xffCEDAE7" />
+			<!--vlandia background-->
+			<Color
+				id="14"
+				hex="0xff8D291A" />
+			<!--vlandia color 2-->
+			<Color
+				id="15"
+				hex="0xffF7BF46" />
+			<Color
+				id="16"
+				hex="0xff6bd5dc" />
+			<Color
+				id="17"
+				hex="0xffeed690" />
+			<Color
+				id="18"
+				hex="0xffaec382" />
+			<Color
+				id="19"
+				hex="0xffc3c3c3" />
+			<Color
+				id="20"
+				hex="0xffd5d7d4" />
+			<Color
+				id="21"
+				hex="0xffe7ecd6" />
+			<Color
+				id="22"
+				hex="0xffeaeeef" />
+			<Color
+				id="23"
+				hex="0xff7f6b60" />
+			<Color
+				id="24"
+				hex="0xff967e7e" />
+			<Color
+				id="25"
+				hex="0xffb6aba7" />
+			<Color
+				id="26"
+				hex="0xffe7d3ba" />
+			<Color
+				id="27"
+				hex="0xffeae1da" />
+			<Color
+				id="28"
+				hex="0xffd9dbce" />
+			<Color
+				id="29"
+				hex="0xffdfd6cd" />
+			<Color
+				id="30"
+				hex="0xffcac1ba" />
+			<Color
+				id="31"
+				hex="0xffece8dd" />
+			<Color
+				id="32"
+				hex="0xffe0dcd9" />
+			<Color
+				id="33"
+				hex="0xffefece5" />
+			<Color
+				id="34"
+				hex="0xffeae9e5" />
+			<Color
+				id="35"
+				hex="0xfff5f5f5" />
+			<Color
+				id="36"
+				hex="0xfff5b365" />
+			<Color
+				id="37"
+				hex="0xfff5b365" />
+			<Color
+				id="38"
+				hex="0xffe68c36" />
+			<Color
+				id="39"
+				hex="0xffdcac46" />
+			<Color
+				id="40"
+				hex="0xffffffff" />
+			<Color
+				id="41"
+				hex="0xffeee7d4" />
+			<Color
+				id="42"
+				hex="0xffe9e2c5" />
+			<Color
+				id="43"
+				hex="0xffebdcbb" />
+			<Color
+				id="44"
+				hex="0xfff0e0a5" />
+			<Color
+				id="45"
+				hex="0xffe0c78e" />
+			<Color
+				id="46"
+				hex="0xffcda87c" />
+			<Color
+				id="47"
+				hex="0xfff9d575" />
+			<Color
+				id="48"
+				hex="0xffe44434" />
+			<Color
+				id="49"
+				hex="0xffe69077" />
+			<Color
+				id="50"
+				hex="0xffe79c7d" />
+			<Color
+				id="51"
+				hex="0xffc94b4e" />
+			<Color
+				id="52"
+				hex="0xffe6b0a6" />
+			<Color
+				id="53"
+				hex="0xffe4c8c7" />
+			<Color
+				id="54"
+				hex="0xfff2b0a2" />
+			<Color
+				id="55"
+				hex="0xffDA6C6D" />
+			<Color
+				id="56"
+				hex="0xffE2BCAF" />
+			<Color
+				id="57"
+				hex="0xffBD7E75" />
+			<Color
+				id="58"
+				hex="0xffD1C7C5" />
+			<Color
+				id="59"
+				hex="0xff975B43" />
+			<Color
+				id="60"
+				hex="0xffE6A57F" />
+			<Color
+				id="61"
+				hex="0xff7B5E4E" />
+			<Color
+				id="62"
+				hex="0xffAC9188" />
+			<Color
+				id="63"
+				hex="0xffD7967A" />
+			<Color
+				id="64"
+				hex="0xffE6C9BB" />
+			<Color
+				id="65"
+				hex="0xff934165" />
+			<Color
+				id="66"
+				hex="0xffD39EB0" />
+			<Color
+				id="67"
+				hex="0xff644974" />
+			<Color
+				id="68"
+				hex="0xff7F658A" />
+			<Color
+				id="69"
+				hex="0xffA793AE" />
+			<Color
+				id="70"
+				hex="0xffC5057C" />
+			<Color
+				id="71"
+				hex="0xff710083" />
+			<Color
+				id="72"
+				hex="0xff00667F" />
+			<Color
+				id="73"
+				hex="0xff00A0BA" />
+			<Color
+				id="74"
+				hex="0xff53B7C6" />
+			<Color
+				id="75"
+				hex="0xffA1B1EF" />
+			<Color
+				id="76"
+				hex="0xff7F8CC0" />
+			<Color
+				id="77"
+				hex="0xff5960A8" />
+			<Color
+				id="78"
+				hex="0xffC1589A" />
+			<Color
+				id="79"
+				hex="0xffA34FAF" />
+			<Color
+				id="80"
+				hex="0xffD08E54" />
+			<Color
+				id="81"
+				hex="0xff939BD9" />
+			<Color
+				id="82"
+				hex="0xffEA4F00" />
+			<Color
+				id="83"
+				hex="0xffD22D33" />
+			<Color
+				id="84"
+				hex="0xffFDE217" />
+			<Color
+				id="85"
+				hex="0xffFFA4DD" />
+			<Color
+				id="86"
+				hex="0xffCB83D5" />
+			<Color
+				id="87"
+				hex="0xff895D5E" />
+			<Color
+				id="88"
+				hex="0xff02FF19" />
+			<Color
+				id="89"
+				hex="0xff019678" />
+			<Color
+				id="90"
+				hex="0xff9EC400" />
+			<Color
+				id="91"
+				hex="0xffA34402" />
+			<Color
+				id="92"
+				hex="0xff714214" />
+			<Color
+				id="93"
+				hex="0xffFFC3C3" />
+			<Color
+				id="94"
+				hex="0xff855FA8" />
+			<Color
+				id="95"
+				hex="0xff7E6E4A" />
+			<Color
+				id="96"
+				hex="0xff3A3321" />
+			<Color
+				id="97"
+				hex="0xff3D2F22" />
+			<Color
+				id="98"
+				hex="0xff422C2E" />
+			<Color
+				id="99"
+				hex="0xff453E38" />
+			<Color
+				id="100"
+				hex="0xff332c4d" />
+			<Color
+				id="101"
+				hex="0xff515267" />
+			<Color
+				id="102"
+				hex="0xff6c72a2" />
+			<Color
+				id="103"
+				hex="0xff8b93ba" />
+			<Color
+				id="104"
+				hex="0xffa6d5db" />
+			<Color
+				id="105"
+				hex="0xffa4b1c2" />
+			<Color
+				id="106"
+				hex="0xffc5bcd1" />
+			<Color
+				id="107"
+				hex="0xffd8aec5" />
+			<Color
+				id="108"
+				hex="0xffcedada" />
+			<Color
+				id="109"
+				hex="0xffd2d6d5" />
+			<Color
+				id="110"
+				hex="0xffcacccb" />
+			<Color
+				id="111"
+				hex="0xffdfdedc" />
+			<Color
+				id="112"
+				hex="0xff5d5b44" />
+			<Color
+				id="113"
+				hex="0xff726b3d" />
+			<Color
+				id="114"
+				hex="0xffcdcc7c" />
+			<Color
+				id="115"
+				hex="0xff8fd1dd" />
+			<Color
+				id="116"
+				hex="0xff0B0C11" />
+			<Color
+				id="117"
+				hex="0xfff5b365" />
+			<!--Referenced for tournament colours-->
+			<Color
+				id="118"
+				hex="0xffE36664" />
+			<!--Referenced for tournament colours-->
+			<Color
+				id="119"
+				hex="0xff456DFF" />
+			<!--Referenced for tournament colours-->
+			<Color
+				id="120"
+				hex="0xff5FBD72" />
+			<!--Referenced for tournament colours-->
+			<Color
+				id="121"
+				hex="0xfff4d32e" />
+			<!--Multiplayer Aserai Background 1-->
+			<Color
+				id="122"
+				hex="0xffa97435" />
+			<!--Multiplayer Aserai Foreground 1-->
+			<Color
+				id="123"
+				hex="0xff41281b" />
+			<!--Multiplayer Aserai Background 2-->
+			<Color
+				id="124"
+				hex="0xff41281b" />
+			<!--Multiplayer Aserai Foreground 2-->
+			<Color
+				id="125"
+				hex="0xffa97435" />
+			<!--Multiplayer Battania Background 1-->
+			<Color
+				id="126"
+				hex="0xff34671e" />
+			<!--Multiplayer Battania Foreground 1-->
+			<Color
+				id="127"
+				hex="0xfff3f3f3" />
+			<!--Multiplayer Battania Background 2-->
+			<Color
+				id="128"
+				hex="0xfff3f3f3" />
+			<!--Multiplayer Battania Foreground 2-->
+			<Color
+				id="129"
+				hex="0xff34671e" />
+			<!--Multiplayer Empire Background 1-->
+			<Color
+				id="130"
+				hex="0xff7739a7" />
+			<!--Multiplayer Empire Foreground 1-->
+			<Color
+				id="131"
+				hex="0xfff1c232" />
+			<!--Multiplayer Empire Background 2-->
+			<Color
+				id="132"
+				hex="0xfff1c232" />
+			<!--Multiplayer Empire Foreground 2-->
+			<Color
+				id="133"
+				hex="0xff7739a7" />
+			<!--Multiplayer Khuzait Background 1-->
+			<Color
+				id="134"
+				hex="0xff5aa4ad" />
+			<!--Multiplayer Khuzait Foreground 1-->
+			<Color
+				id="135"
+				hex="0xffffe9d4" />
+			<!--Multiplayer Khuzait Background 2-->
+			<Color
+				id="136"
+				hex="0xffffe9d4" />
+			<!--Multiplayer Khuzait Foreground 2-->
+			<Color
+				id="137"
+				hex="0xff5aa4ad" />
+			<!--Multiplayer Sturgia Background 1-->
+			<Color
+				id="138"
+				hex="0xff3a6298" />
+			<!--Multiplayer Sturgia Foreground 1-->
+			<Color
+				id="139"
+				hex="0xffd9d9d9" />
+			<!--Multiplayer Sturgia Background 2-->
+			<Color
+				id="140"
+				hex="0xffd9d9d9" />
+			<!--Multiplayer Sturgia Foreground 2-->
+			<Color
+				id="141"
+				hex="0xff3a6298" />
+			<!--Multiplayer Vlandia Background 1-->
+			<Color
+				id="142"
+				hex="0xff830808" />
+			<!--Multiplayer Vlandia Foreground 1-->
+			<Color
+				id="143"
+				hex="0xfff4ca14" />
+			<!--Multiplayer Vlandia Background 2-->
+			<Color
+				id="144"
+				hex="0xfff4ca14" />
+			<!--Multiplayer Vlandia Foreground 2-->
+			<Color
+				id="145"
+				hex="0xff830808" />
+			<Color
+				id="146"
+				hex="0xff2C4D86" />
+			<Color
+				id="147"
+				hex="0xff955066" />
+			<Color
+				id="148"
+				hex="0xff6c1512" />
+			<Color
+				id="149"
+				hex="0xff211f1f" />
+			<Color
+				id="150"
+				hex="0xffccc4bf" />
+			<Color
+				id="151"
+				hex="0xffef9b9b" />
+			<Color
+				id="152"
+				hex="0xffb5d0fd" />
+			<Color
+				id="153"
+				hex="0xffa8ceab" />
+			<Color
+				id="154"
+				hex="0xff8d5c44" />
+			<Color
+				id="155"
+				hex="0xffe9a74d" />
+			<Color
+				id="156"
+				hex="0xffb3a491" />
+			<!--Player Clan Primary-->
+			<Color
+				id="157"
+				hex="0xff5f4f44" />
+			<!--Player Clan Secondary-->
+			<!--Banner Editor Colors-->
+			<Color
+				id="158"
+				hex="0xff234116"
+				player_can_choose_for_background="true" />
+			<Color
+				id="159"
+				hex="0xff26406d"
+				player_can_choose_for_background="true" />
+			<Color
+				id="160"
+				hex="0xff7a4253"
+				player_can_choose_for_background="true" />
+			<Color
+				id="161"
+				hex="0xff5a1310"
+				player_can_choose_for_background="true" />
+			<Color
+				id="162"
+				hex="0xff2f2a2b"
+				player_can_choose_for_background="true" />
+			<Color
+				id="163"
+				hex="0xff744c38"
+				player_can_choose_for_background="true" />
+			<Color
+				id="164"
+				hex="0xff594012"
+				player_can_choose_for_background="true" />
+			<Color
+				id="165"
+				hex="0xffbf5a25"
+				player_can_choose_for_background="true" />
+			<Color
+				id="166"
+				hex="0xffffcf83"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="167"
+				hex="0xff85827f"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="168"
+				hex="0xffce9697"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="169"
+				hex="0xff95a9cc"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="170"
+				hex="0xff89a78b"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="171"
+				hex="0xffffb53e"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="172"
+				hex="0xffffffff"
+				player_can_choose_for_sigil="true" />
+			<Color
+				id="173"
+				hex="0xffc7beb7"
+				player_can_choose_for_sigil="true" />
+			<!--Minor Faction Banner Colors-->
+			<Color
+				id="174"
+				hex="0xFFB38841" />
+			<Color
+				id="175"
+				hex="0xFF848B65" />
+			<Color
+				id="176"
+				hex="0xFF5A7A4F" />
+			<Color
+				id="177"
+				hex="0xFF7CAFC7" />
+			<Color
+				id="178"
+				hex="0xFF7C2B1A" />
+			<Color
+				id="179"
+				hex="0xFFAC5F2E" />
+			<Color
+				id="180"
+				hex="0xFF72583B" />
+			<Color
+				id="181"
+				hex="0xFF61725E" />
+			<Color
+				id="182"
+				hex="0xFFA6825C" />
+			<Color
+				id="183"
+				hex="0xFFCCC3AB" />
+			<Color
+				id="184"
+				hex="0xFF8B7C73" />
+			<Color
+				id="185"
+				hex="0xFFD0884E" />
+			<Color
+				id="186"
+				hex="0xFF7B5869" />
+			<Color
+				id="187"
+				hex="0xFF66CCFF" />
+			<Color
+				id="188"
+				hex="0xFFAA415D" />
+			<!--Bandit Banner Colors-->
+			<!--Forest Bandits-->
+			<Color
+				id="189"
+				hex="0xFF687f5e" />
+			<!--Sea Raiders-->
+			<Color
+				id="190"
+				hex="0xFF4E75BC" />
+			<!--Desert Bandits-->
+			<Color
+				id="191"
+				hex="0xFFf1c178" />
+			<!--Steppe Bandits-->
+			<Color
+				id="192"
+				hex="0xFFd1c4a4" />
+			<!--Looters-->
+			<Color
+				id="193"
+				hex="0xFF5e5737" />
+		</BannerColors>
+	</BannerIconData>
+</base>

--- a/BannerlordModEditor.Common.Tests/TestData/SourceFiles/mpitems.xml
+++ b/BannerlordModEditor.Common.Tests/TestData/SourceFiles/mpitems.xml
@@ -1,0 +1,22586 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Items>
+	<!-- #region Armors -->
+	<!-- #region Aserai Armors -->
+	<!-- #region Aserai Head Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_pointed_skullcap_over_cloth_headwrap"
+		name="{=LqA9uBH9}Pointed Skullcap over Cloth Headwrap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_l_d"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		difficulty="0"
+		appearance="0.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="all" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_civil_c_head"
+		name="{=ZFETxZKP}Keffiyeh with Silken Band"
+		mesh="aserai_civil_c_head"
+		culture="Culture.aserai"
+		value="1"
+		weight="0.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="2"
+				has_gender_variations="true"
+				hair_cover_type="type2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_aserai_civil_d_hscarf"
+		name="{=l91l1TJo}Colored Turban"
+		mesh="aserai_civil_d_hscarf"
+		culture="Culture.aserai"
+		value="1"
+		weight="0.1"
+		appearance="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="4"
+				has_gender_variations="true"
+				hair_cover_type="type1"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_aserai_civil_hscarf_b"
+		name="{=OrEgjXZ1}Roughspun Keffiyeh"
+		mesh="aserai_civil_hscarf_b"
+		culture="Culture.aserai"
+		value="1"
+		weight="0.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="2"
+				has_gender_variations="true"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_aserai_civil_hscarf_a"
+		name="{=2KHcAWiq}Keffiyeh with Cloth Band"
+		mesh="aserai_civil_hscarf_a"
+		culture="Culture.aserai"
+		value="1"
+		weight="0.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="2"
+				has_gender_variations="true"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_aserai_civil_e_hscarf"
+		name="{=spcj3XIw}Wrapped Keffiyeh"
+		mesh="aserai_civil_e_hscarf"
+		culture="Culture.aserai"
+		value="1"
+		weight="0.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="2"
+				has_gender_variations="true"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wrapped_desert_cap"
+		name="{=3UxfT9Bu}Wrapped Leather Cap"
+		mesh="aserai_helmet_o"
+		culture="Culture.aserai"
+		value="1"
+		weight="0.5"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="6"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				beard_cover_type="type2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_helmet"
+		name="{=BryUh6yQ}Steel Cap"
+		mesh="aserai_helmet_n"
+		culture="Culture.aserai"
+		value="1"
+		weight="1.2"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="17"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_lord_helmet_a"
+		name="{=eso5zk60}Aserai Lord Helmet"
+		mesh="aserai_lord_helmet_a"
+		culture="Culture.aserai"
+		value="1"
+		weight="3.7"
+		appearance="0.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="43"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_southern_noble_helmet"
+		name="{=GFKPrrb8}Aserai Noble Helmet"
+		mesh="aserai_lord_helmet_b"
+		culture="Culture.aserai"
+		value="1"
+		weight="3.7"
+		appearance="0.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="43"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_southern_lord_helmet"
+		name="{=eso5zk60}Aserai Lord Helmet"
+		mesh="aserai_lord_helmet_c"
+		culture="Culture.aserai"
+		value="1"
+		weight="3.7"
+		appearance="0.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="43"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Aserai Shoulder Armors -->
+	<Item
+		id="mp_brass_scale_shoulders"
+		name="{=CyJiWngO}Bronze Scale Shoulders"
+		mesh="sturgia_leather_brass_shoulder"
+		culture="Culture.sturgia"
+		value="1"
+		weight="2.2"
+		appearance="0.9"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		id="mp_desert_fabric_shoulderpad"
+		name="{=FyXM8Iob}Desert Fabric Shoulderpad"
+		mesh="aserai_bigchain_shoulder_fabric"
+		culture="Culture.aserai"
+		value="1"
+		weight="1.8"
+		appearance="0.1"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Aserai Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_southern_lamellar_armor"
+		name="{=3lauB1HH}Bronze Lamellar Vest over Gambeson"
+		subtype="body_armor"
+		mesh="sturgia_costume_i_yellow"
+		culture="Culture.aserai"
+		value="1"
+		weight="8.8"
+		difficulty="0"
+		appearance="0.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				leg_armor="4"
+				arm_armor="1"
+				has_gender_variations="true"
+				modifier_group="plate"
+				covers_body="true"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tassled_southern_robes"
+		name="{=cMdtLfGB}Tassled Robes"
+		mesh="aserai_thobe"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Aserai Arm Armors -->
+	<!-- #endregion -->
+	<!-- #region Aserai Leg Armors -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Battania Armors -->
+	<!-- #region Battania Head Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_rough_bearskin"
+		name="{=KKWEkA4P}Rough Bearskin"
+		mesh="cloak_fur_c"
+		culture="Culture.battania"
+		value="1"
+		weight="2.3"
+		appearance="0.7"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Battania Shoulder Armors -->
+	<!-- #endregion -->
+	<!-- #region Battania Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_kilt_over_plated_leather"
+		name="{=fptsl0Qn}Kilt over Plated Leather"
+		mesh="leather_armor_kilt"
+		subtype="body_armor"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="7.8"
+		difficulty="0"
+		appearance="0.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="30"
+				leg_armor="16"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Battania Arm Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_strapped_leather_bracers"
+		name="{=DOYS7dmq}Strapped Leather Bracers"
+		mesh="bandit_10_wristband"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		appearance="0.3"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="3"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Battania Leg Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_ragged_boots"
+		name="{=Szuxa9Bs}Ragged Boots"
+		mesh="sneak_costume_foot"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		difficulty="0"
+		appearance="0.3"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="8"
+				covers_legs="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Khuzait Armors -->
+	<!-- #region Khuzait Head Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_nomad_padded_hood"
+		name="{=yMi4ijgI}Nomad Padded Hood"
+		subtype="head_armor"
+		mesh="khuzait_helmet_p"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="4"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_nordic_fur_cap"
+		name="{=cjH1WFwy}Fur Rimmed Cap"
+		mesh="sturgia_helmet_m"
+		culture="Culture.sturgia"
+		value="1"
+		weight="0.3"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="10"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				beard_cover_type="none"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_lamellar_armor"
+		name="{=hXB6gvD2}Cured Leather Lamellar Shirt "
+		subtype="body_armor"
+		mesh="sturgia_costume_h"
+		culture="Culture.sturgia"
+		value="1"
+		weight="1.9"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				leg_armor="3"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Khuzait Shoulder Armors -->
+	<!-- #endregion -->
+	<!-- #region Khuzait Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_civil_coat_b"
+		name="{=S1XL4KJh}Luxury Thick Coat"
+		mesh="khuzait_civil_coat_b"
+		culture="Culture.khuzait"
+		value="1"
+		weight="2.7"
+		appearance="0.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="1"
+				arm_armor="0"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Khuzait Arm Armors -->
+	<!-- #endregion -->
+	<!-- #region Khuzait Leg Armors -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Vlandia Armors -->
+	<!-- #region Vlandia Head Armors -->
+	<Item
+		id="mp_pointed_skullcap_over_mail"
+		name="{=xS7m37o7}Pointed Skullcap over Mail"
+		mesh="vlandia_helmet_l_b"
+		culture="Culture.aserai"
+		value="1"
+		weight="1.3"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="19"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_cervelliere_over_padded_cap"
+		name="{=4BfbPgkY}Nasal Cervelliere over Padded Cap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_o_e"
+		culture="Culture.vlandia"
+		value="1"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_cervelliere_over_mail_coif"
+		name="{=mRGIxvYh}Nasal Cervelliere over Mail Coif"
+		mesh="vlandia_helmet_o_a"
+		culture="Culture.vlandia"
+		value="1"
+		weight="2.6"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="21"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_leather_cape"
+		name="{=SHZ0P7Iu}Padded Leather Cape"
+		subtype="head_armor"
+		mesh="shoulder_padding_cape"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_cervelliere_over_padded_coif"
+		name="{=JjLQ2VdT}Nasal Cervelliere over Padded Coif"
+		mesh="vlandia_helmet_o_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="22"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Vlandia Shoulder Armors -->
+	<!-- #endregion -->
+	<!-- #region Vlandia Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_red_coat_over_mail"
+		name="{=NTPmtaaN}Red Coat over Mail"
+		subtype="body_armor"
+		mesh="templar_a_red"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="8.2"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="24"
+				leg_armor="13"
+				arm_armor="11"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Vlandia Arm Armors -->
+	<!-- #endregion -->
+	<!-- #region Vlandia Leg Armors -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Sturgia Armors -->
+	<!-- #region Sturgia Head Armors -->
+	<!-- #endregion -->
+	<!-- #region Sturgia Shoulder Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_shoulders"
+		name="{=JkLoAelJ}Mail Shoulders"
+		mesh="shoulder_chain_a"
+		culture="Culture.sturgia"
+		value="1"
+		subtype="body_armor"
+		is_merchandise="false"
+		weight="2.7"
+		difficulty="0"
+		appearance="0.6"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Sturgia Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_brass_lamellar_over_mail"
+		name="{=2w09rN4S}Heavy Bronze Lamellar over Mail"
+		mesh="brass_lamellar_white"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="11.4"
+		appearance="0.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="38"
+				leg_armor="13"
+				arm_armor="13"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Sturgia Arm Armors -->
+	<!-- #endregion -->
+	<!-- #region Sturgia Leg Armors -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Empire Armors -->
+	<!-- #region Empire Head Armors -->
+	<Item
+		id="mp_merchants_hat"
+		name="{=S9htzkbe}Merchant Hat"
+		mesh="costume_merchant_v4_head"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="2"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_cervelliere_over_padded_cloth"
+		name="{=vsavMoLZ}Segmented Cervelliere over Padded Cloth"
+		subtype="head_armor"
+		mesh="vlandia_helmet_u_y"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Empire Shoulder Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_woven_leather_shoulders"
+		name="{=c7UNJSNi}Woven Leather Shoulders"
+		mesh="vlandia_leather_stripes_shoulders"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		appearance="0.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Empire Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_mail_vest"
+		name="{=Kr8b1bxY}Infantryman Mail Vest"
+		mesh="empire_armor_e"
+		culture="Culture.empire"
+		value="1"
+		subtype="body_armor"
+		is_merchandise="false"
+		weight="7.8"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="23"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Empire Arm Armors -->
+	<!-- #endregion -->
+	<!-- #region Empire Leg Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_folded_town_boots"
+		name="{=oH8iFEv7}Folded Town Boots"
+		mesh="casual_01_boots"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		appearance="0.7"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="7"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_nasalhelm_over_imperial_leather"
+		name="{=vimhFdZp}Heavy Nasalhelm over Leather"
+		mesh="empire_helmet_g_d"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.0"
+		appearance="0.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Looters Armors -->
+	<!-- #region Looters Head Armors -->
+	<!-- #endregion -->
+	<!-- #region Looters Shoulder Armors -->
+	<!-- #endregion -->
+	<!-- #region Looters Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_dummy_armor_min"
+		name="{=Zx4h7jDy}Dummy Min Armor"
+		mesh="gambeson_b"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="10"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				leg_armor="0"
+				head_armor="0"
+				arm_armor="0"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_dummy_armor_lower_average"
+		name="{=K2xGw3Oo}Dummy Lower Average"
+		mesh="sturgia_costume_m"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="12"
+				head_armor="12"
+				arm_armor="12"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_dummy_armor_higher_average"
+		name="{=gT8WENO3}Dummy Higher Average"
+		mesh="vlandia_leather_armor"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="30"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="37"
+				head_armor="37"
+				arm_armor="37"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_dummy_armor_max"
+		name="{=wSUN0Dmo}Dummy Max Armor"
+		mesh="vlandia_scale_armor"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="40"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="55"
+				leg_armor="55"
+				head_armor="55"
+				arm_armor="55"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_tunic"
+		name="{=W58TN2g5}Varyag Tunic"
+		subtype="body_armor"
+		mesh="sturgia_costume_j"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_fur_armor"
+		name="{=tXbRb3QO}Studded Fur Armor"
+		mesh="bandit_1_d"
+		subtype="body_armor"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		difficulty="0"
+		appearance="0.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				leg_armor="3"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_bandit_b"
+		name="{=BavVxSoC}Cheap Colored Clothes"
+		mesh="vlandia_bandit_b"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bandit_fur_a"
+		name="{=TfDFlmpb}Loathsome Fur Armor"
+		mesh="bandit_fur_a"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				leg_armor="1"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_buckled_wildsman_armor"
+		name="{=8oKVhtth}Buckled Brigandine Armor"
+		mesh="bandit_2"
+		subtype="body_armor"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="12.3"
+		difficulty="0"
+		appearance="0.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="2"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Looters Arm Armors -->
+	<!-- #endregion -->
+	<!-- #region Looters Leg Armors -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Armors -->
+	<!-- #region NeutralCulture Head Armors -->
+	<!-- #region NeutralCulture Light Head Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_civil_hood"
+		name="{=UC2XfY7V}Cloth Hood"
+		subtype="head_armor"
+		mesh="battania_civil_hood"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="9"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasalhelm_over_mail"
+		name="{=1bdDdwub}Nasalhelm over Mail"
+		mesh="sturgia_helmet_a"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="29"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_noble_helmet_with_neckguard"
+		name="{=LyaWykYa}Noble Helmet with Neckguard"
+		mesh="khuzait_lord_helmet_b"
+		culture="Culture.khuzait"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="39"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_laced_coif"
+		name="{=qFL0VxZX}Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="9"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_arming_coif"
+		name="{=mlJKNbbn}Leather Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_f"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="0.3"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="11"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_leather_coif"
+		name="{=mlJKNbbn}Leather Coif"
+		subtype="head_armor"
+		mesh="empire_helmet_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="3"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_noble_helmet_with_fur"
+		name="{=4iqTIpAs}Noble Helmet with Fur"
+		mesh="khuzait_lord_helmet_c"
+		culture="Culture.khuzait"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="3.9"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_hood"
+		name="{=jjHpXY4d}Fur Hood"
+		subtype="head_armor"
+		mesh="khuzait_helmet_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="9"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_peaked_fur_hood"
+		name="{=8tHbqjmB}Peaked Fur Hood"
+		subtype="head_armor"
+		mesh="khuzait_helmet_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="10"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_closed_head_scarf"
+		name="{=gUTqDROO}Closed Head Scarf"
+		subtype="head_armor"
+		mesh="aserai_helmet_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="9"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_trailed_desert_helmet"
+		name="{=2N0ZP2GB}Helmet with Turban and Coif"
+		subtype="head_armor"
+		mesh="aserai_helmet_g"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="14"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type1"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_mail_coif"
+		name="{=0LoGEHxz}Desert Mail Coif"
+		subtype="head_armor"
+		mesh="aserai_helmet_j"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="3.0"
+		difficulty="0"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail"
+				beard_cover_type="type4" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_woven_turban"
+		name="{=ArPvuBYK}Woven Turban"
+		subtype="head_armor"
+		mesh="aserai_helmet_h"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		appearance="0.5"
+		difficulty="0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="8"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth"
+				beard_cover_type="type4" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_cap"
+		name="{=gTptIfxY}Desert Cap"
+		mesh="aserai_helmet_m"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="4"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				beard_cover_type="none"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_open_head_scarf"
+		name="{=qsVRoGUv}Open Head Scarf"
+		mesh="aserai_helmet_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="8"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_turban"
+		name="{=8SNS2wF9}Turban"
+		mesh="aserai_helmet_i"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="7"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_headdress"
+		name="{=4n6n3KL7}Desert Headdress"
+		mesh="aserai_female_costume_headdress"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="3"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tuareg"
+		name="{=9rXUVscR}Tuareg"
+		subtype="head_armor"
+		mesh="tuareg_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="5"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth"
+				beard_cover_type="type1" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_over_mail"
+		name="{=zZ2G7uIO}Kettle Helmet over Mail"
+		mesh="vlandia_helmet_h_v"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="3.1"
+		appearance="0.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="29"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_leather_cap"
+		name="{=ByxdPJzA}Fur Cap with Ear Flaps"
+		subtype="head_armor"
+		mesh="sturgia_leather_cap_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="5"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roughhide_cap"
+		name="{=p6NIgRpk}Roughhide Cap"
+		mesh="sturgia_helmet_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="5"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				beard_cover_type="none"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_fur_cap"
+		name="{=TwuAVsCn}Fur Cap"
+		mesh="sturgia_helmet_j"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="4"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				beard_cover_type="none"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_thinhide_coif"
+		name="{=Q50hfNjW}Thinhide Coif"
+		subtype="head_armor"
+		mesh="battania_helmet_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="5"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wrapped_headcloth"
+		name="{=hRHPPQQP}Wrapped Headcloth"
+		subtype="head_armor"
+		mesh="battania_helmet_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="3"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_studdedhelm"
+		name="{=TGpFbISX}Leather Studded Helm"
+		subtype="head_armor"
+		mesh="battania_helmet_k"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="9"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tied_head_wrapping"
+		name="{=ndfDy5B8}Tied Head Wrapping"
+		subtype="head_armor"
+		mesh="aserai_helmet_p"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="8"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth"
+				beard_cover_type="type4" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tight_head_scarf"
+		name="{=U4n0uSlg}Tight Head Scarf"
+		subtype="head_armor"
+		mesh="aserai_helmet_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="9"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth"
+				beard_cover_type="all" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_pilgrim_hood"
+		name="{=rzhIJ8Yh}Pilgrim Hood"
+		mesh="sneak_costume_head"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="2"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_cap"
+		name="{=uLpnmNkZ}Leather Cap"
+		subtype="head_armor"
+		mesh="leather_cap_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="8"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="type2"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_cloth_coif"
+		name="{=g5BPd0Oc}Cloth Coif"
+		subtype="head_armor"
+		mesh="empire_helmet_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="3"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_hat"
+		name="{=73U5RElj}Fur Hat"
+		subtype="head_armor"
+		mesh="khuzait_helmet_o"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="4"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_cap"
+		name="{=h9PP7EWc}Cap with Neck Flap"
+		subtype="head_armor"
+		mesh="khuzait_helmet_n"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="5"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_helmet"
+		name="{=EOz0edW4}Steppe Helmet"
+		subtype="head_armor"
+		mesh="khuzait_helmet_l"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_upturned_fur_cap"
+		name="{=3bqwOJ8z}Upturned Fur Cap"
+		subtype="head_armor"
+		mesh="khuzait_helmet_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="8"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_cap"
+		name="{=Dc4ia4m9}Padded Cap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="5"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Medium Head Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_ironlame_feathered_spangenhelm_over_leather"
+		name="{=tiSffNik}Ironlame Feathered Spangenhelm over Leather"
+		mesh="empire_helmet_i_db"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		difficulty="0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="31"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leatherlame_feathered_spangenhelm_over_leather"
+		name="{=bzrVXGAl}Bronze Feathered Spangenhelm over Leather"
+		mesh="empire_helmet_i_da"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.7"
+		appearance="0.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="29"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ironlame_spiked_kettle_over_mail"
+		name="{=IX3kafcb}Iron Spiked Kettle over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_k_fb"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.8"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="33"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_guards_kettle_over_laced_coif"
+		name="{=20moIxs1}Kettle over Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_j_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		difficulty="0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_with_leather"
+		name="{=ZV1bKLUn}Kettle Helmet with Leather"
+		subtype="head_armor"
+		mesh="kettle_helmet_leather"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1"
+		difficulty="0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_peaked_helmet_over_laced_coif"
+		name="{=Rhfp7ath}Peaked Helmet over Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_t_c"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		difficulty="0"
+		appearance="1.8"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_peaked_helmet_over_padded_cloth"
+		name="{=TFT2Xapz}Peaked Helmet over Padded Cloth"
+		subtype="head_armor"
+		mesh="vlandia_helmet_t_y"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_peaked_helmet_over_mail_coif"
+		name="{=AdafHtud}Peaked Helmet over Mail Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_t_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_peaked_helmet_over_mail"
+		name="{=JvhvtKsT}Peaked Helmet over Mail"
+		mesh="vlandia_helmet_t_v"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		appearance="1.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="40"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_over_padded_cloth"
+		name="{=bubcrmTC}Nasal Helmet over Padded Cloth"
+		mesh="vlandia_helmet_p_y"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_hat_over_padded_cloth"
+		name="{=wBfGpcCO}Kettle Hat over Padded Cloth"
+		subtype="head_armor"
+		mesh="vlandia_helmet_i_y"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_skullcap_over_padded_cloth"
+		name="{=b1pqUQju}Segmented Skullcap over Padded Cloth"
+		subtype="head_armor"
+		mesh="vlandia_helmet_r_y"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="17"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_over_laced_coif"
+		name="{=AB1mV5Pg}Kettle Helmet over Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_h_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="17"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_decorated_nomad_cap"
+		name="{=smHA8Apa}Decorated Nomad Cap"
+		mesh="khuzait_helmet_i"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		appearance="1.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="6"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				beard_cover_type="none"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_spangenhelm_with_padded_cloth"
+		name="{=ebHdQfbX}Spangenhelm with Padded Cloth"
+		subtype="head_armor"
+		mesh="spangenhelm_arming"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="1.9"
+		difficulty="0"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_visored_helmet_over_padded_coif"
+		name="{=agqzAXa9}Visored Helmet over Padded Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_m_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="27"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plumed_nomad_helmet"
+		name="{=m3Nv9rt2}Plumed Nomad Helmet"
+		mesh="khuzait_helmet_k"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wolfhead"
+		name="{=aGvBKCG8}Wolfhead"
+		subtype="head_armor"
+		mesh="battania_helmet_i"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roundkettle_over_laced_cloth"
+		name="{=9BENgwRK}Roundkettle over Laced Cloth"
+		subtype="head_armor"
+		mesh="empire_helmet_j_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roundkettle_over_imperial_leather"
+		name="{=aOwcs7Un}Roundkettle over Leather"
+		subtype="head_armor"
+		mesh="empire_helmet_j_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_heavy_cavalry_helmet"
+		name="{=xl5MgK49}Sturgia Heavy Cavalry Helmet"
+		mesh="sturgia_helmet_o"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_nasal_helm"
+		name="{=rSEXAMUx}Legionary Helm"
+		subtype="head_armor"
+		mesh="empire_helmet_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="21"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tall_helmet"
+		name="{=9FgxK9se}Tall Helmet"
+		subtype="head_armor"
+		mesh="roman_helmet_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="19"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nomad_helmet"
+		name="{=WvDZMmaj}Nomad Helmet"
+		subtype="head_armor"
+		mesh="khuzait_helmet_j"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="17"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plumed_fur_lined_helmet"
+		name="{=ZRDoABz9}Plumed Fur Lined Helmet"
+		subtype="head_armor"
+		mesh="khuzait_helmet_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_warlord_helmet"
+		name="{=y9uZrJv2}Sturgian Warlord Helmet"
+		mesh="sturgia_helmet_i"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		appearance="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="type1"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_open_desert_helmet"
+		name="{=QVGL3eB0}Open Desert Helmet"
+		subtype="head_armor"
+		mesh="aserai_helmet_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_loose_wrapped_desert_helmet"
+		name="{=WXjQNIJW}Loose Wrapped Desert Helmet"
+		mesh="aserai_helmet_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_closed_desert_helmet"
+		name="{=WiPJqTXv}Closed Desert Helmet"
+		mesh="aserai_helmet_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="19"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_fur_helmet"
+		name="{=2iaLi16f}Highland Hide Helmet"
+		subtype="head_armor"
+		mesh="battania_fur_helmet_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="true"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_studdedhelm_over_thinhide"
+		name="{=2m1kWsao}Leather Studded Helm over Thinhide"
+		subtype="head_armor"
+		mesh="battania_helmet_k_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_studdedhelm_over_headcloth"
+		name="{=beMSPAOG}Leather Studded Helm over Headcloth"
+		subtype="head_armor"
+		mesh="battania_helmet_k_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="14"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_studdedhelm_over_roughscale"
+		name="{=X1Wn0sBa}Leather Studded Helm over Roughscale"
+		subtype="head_armor"
+		mesh="battania_helmet_k_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="34"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ridged_northernhelm"
+		name="{=x1kf94SW}Ridged Helm"
+		subtype="head_armor"
+		mesh="battania_helmet_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_bandit_cape_a"
+		name="{=ewSpZ10R}Rough Padded Cap"
+		subtype="head_armor"
+		mesh="vlandia_bandit_cape_a"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		difficulty="0"
+		appearance="0.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_bandit_cape_b"
+		name="{=7D3jvAfS}Hide Cap"
+		subtype="head_armor"
+		mesh="vlandia_bandit_cape_b"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		difficulty="0"
+		appearance="0.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leatherlame_nasalhelm_over_imperial_leather"
+		name="{=ihN5JZ9h}Nasalhelm over Leather"
+		subtype="head_armor"
+		mesh="empire_helmet_h_da"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_helmet_with_faceguard"
+		name="{=UoHZGyZa}Helmet with Faceguard"
+		subtype="head_armor"
+		mesh="roman_helmet_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="33"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roundkettle_over_imperial_cloth"
+		name="{=MChutiV6}Roundkettle over Cloth"
+		mesh="empire_helmet_j_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="14"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_goggled_helmet_over_leather"
+		name="{=0PSC0Vkf}Goggled Helmet over Leather"
+		mesh="sturgia_helmet_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="19"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet"
+		name="{=v23z53yg}Nasal Helmet"
+		mesh="nasal_helmet_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="14"
+				has_gender_variations="false"
+				hair_cover_type="type1"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_helmet"
+		name="{=rysPCUOp}Northlander Helmet"
+		mesh="sturgia_masked_helm_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_over_laced_coif"
+		name="{=FWFDkjBk}Nasal Helmet over Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_p_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_over_arming_coif"
+		name="{=3iq3rOh8}Kettle Helmet over Arming Coif"
+		mesh="vlandia_helmet_h_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="28"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_over_padded_coif"
+		name="{=1GpTOIqU}Kettle Helmet over Padded Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_h_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		difficulty="0"
+		appearance="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="22"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_skullcap_over_laced_coif"
+		name="{=VylHwqVq}Segmented Skullcap over Laced Coif"
+		mesh="vlandia_helmet_r_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Heavy Head Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_cervelliere_over_arming_coif"
+		name="{=7dAy51ln}Cervelliere over Arming Coif"
+		mesh="vlandia_helmet_n_f"
+		culture="Culture.vlandia"
+		weight="0.9"
+		value="1"
+		is_merchandise="false"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_cervelliere_over_mail_coif"
+		name="{=WMqHlEvb}Segmented Cervelliere over Mail Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_u_a"
+		culture="Culture.neutral_culture"
+		weight="3.2"
+		value="1"
+		is_merchandise="false"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_full_helm_over_mail_coif"
+		name="{=FsDZC8Yl}Full Helm over Mail Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_s_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="40"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_western_crowned_plated_helmet"
+		name="{=PxVFJaEM}Crowned Plated Helmet"
+		mesh="vlandia_lord_helmet_c"
+		culture="Culture.neutral_culture"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="3.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="39"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_over_mail_coif"
+		name="{=PVgSGCYK}Nasal Helmet over Mail Coif"
+		mesh="vlandia_helmet_p_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_hat_over_mail_coif"
+		name="{=tMLH04n4}Kettle Hat over Mail Coif"
+		mesh="vlandia_helmet_i_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_open_mail_coif"
+		name="{=OpYdqPWs}Open Mail Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_v"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		difficulty="0"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_coif"
+		name="{=Qywm0F8B}Mail Coif with Helmet Padding"
+		subtype="head_armor"
+		mesh="vlandia_helmet_a"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.7"
+		difficulty="0"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="18"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail"
+				beard_cover_type="type4" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_visored_helmet_over_mail_coif"
+		name="{=d8DrtmwP}Visored Helmet over Mail Coif"
+		mesh="vlandia_helmet_m_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_skullcap_over_mail_coif"
+		name="{=P8GrNSkF}Segmented Skullcap over Mail Coif"
+		mesh="vlandia_helmet_r_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="34"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_skullcap_over_padded_coif"
+		name="{=zAvb7WKe}Segmented Skullcap over Padded Coif"
+		mesh="vlandia_helmet_r_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="19"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type1"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plumed_helmet"
+		name="{=sJ1R62Tn}Plumed Helmet"
+		subtype="head_armor"
+		mesh="roman_helmet_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="31"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_goggled_helmet"
+		name="{=5bEHZ2z1}Imperial Goggled Helmet"
+		mesh="imperial_helmet"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_decorated_goggled_helmet"
+		name="{=newiAaR9}Decorated Goggled Helmet"
+		mesh="sturgia_helmet_n"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roundkettle_over_imperial_mail"
+		name="{=tYmOCuuQ}Roundkettle over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_j_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leatherlame_feathered_spangenhelm_over_mail"
+		name="{=aoPbMKwB}Feathered Spangenhelm over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_i_aa"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plumed_lamellar_helmet"
+		name="{=YqhOxb1Z}Plumed Lamellar Helmet"
+		subtype="head_armor"
+		mesh="khuzait_helmet_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="33"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_vendel_helmet"
+		name="{=QCOWP3E9}Steppe Raider Helmet"
+		mesh="khuzait_helmet_m"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_spiked_helmet"
+		name="{=ygfhbfr0}Spiked Helmet"
+		subtype="head_armor"
+		mesh="khuzait_helmet_g"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="4.5"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_spiked_helmet_with_facemask"
+		name="{=5n4rWI9T}Spiked Helmet with Facemask"
+		subtype="head_armor"
+		mesh="khuzait_helmet_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="40"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_pointed_skullcap_with_mail"
+		name="{=3DV3GoHb}Pointed Skullcap with Mail"
+		subtype="head_armor"
+		mesh="vlandia_helmet_l_v"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="29"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_closed_desert_helmet_with_mail"
+		name="{=XOC81pVz}Closed Desert Helmet with Mail"
+		mesh="aserai_helmet_k"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="34"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_emirs_helmet"
+		name="{=efW2XbK8}Emir Helmet"
+		subtype="head_armor"
+		mesh="aserai_helmet_r"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.0"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="33"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_goggled_helmet"
+		name="{=RIswqnuJ}Goggled Helmet"
+		mesh="sturgia_helmet_k"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="31"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_lendman_helmet_over_mail"
+		name="{=cVYVpeBS}Raider Helmet over Mail"
+		mesh="sturgia_helmet_g"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9.1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lord_helmet_b"
+		name="{=n7c7tnx9}Warlord Helmet with Nose Guard"
+		mesh="sturgian_lord_helmet_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.4"
+		difficulty="0"
+		appearance="0.8"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_goggled_helmet_over_full_mail"
+		name="{=mU5CY4bz}Closed Huscarl Helmet"
+		mesh="sturgia_helmet_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.4"
+		appearance="1.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="51"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_battle_crown_west"
+		name="{=EOplBvKz}Imperial Plumed Helmet"
+		subtype="head_armor"
+		mesh="empire_battle_crown_west"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.1"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="48"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_battle_crown_north"
+		name="{=AK0lNDmN}Jeweled Plumed Battle Crown"
+		subtype="head_armor"
+		mesh="empire_battle_crown_north"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="45"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_battle_crown"
+		name="{=aQeOcLX4}Two Pronged Bronze Crown"
+		mesh="battania_battle_crown"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="2.3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="40"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_battle_crown"
+		name="{=5c4cHL9Z}Khuzait Battle Crown"
+		mesh="khuzait_battle_crown"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="2.7"
+		difficulty="0"
+		appearance="4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_battle_crown"
+		name="{=fBAf3OWb}Ornate Desert Battle Crown"
+		subtype="head_armor"
+		mesh="aserai_battle_crown"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		difficulty="0"
+		appearance="9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="44"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_crown"
+		name="{=6Dk7LClc}Luxury Turban Over Helmet"
+		mesh="aserai_crown"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		appearance="8"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="42"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lord_helmet_c"
+		name="{=vmJLhccb}Decorated Helmet"
+		mesh="sturgian_lord_helmet_c"
+		culture="Culture.neutral_culture"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="4.4"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="40"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_plated_noble_helmet"
+		name="{=KpyTaAwL}Highland Plated Noble Helmet"
+		mesh="battania_lord_helmet_a"
+		culture="Culture.neutral_culture"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="2.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_noble_helmet_with_feather"
+		name="{=H41qKfaL}Highland Noble Helmet with Feather"
+		mesh="battania_lord_helmet_b"
+		culture="Culture.neutral_culture"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="3.1"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_crowned_helmet"
+		name="{=YDibTDob}Highland Crowned Helmet"
+		mesh="battania_lord_helmet_c"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="42"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roughscale_helmet"
+		name="{=jakLnIQv}Roughscale Helmet"
+		subtype="head_armor"
+		mesh="battania_helmet_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="31"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_closed_goggled_helmet"
+		name="{=TjoKgbV6}Closed Goggled Helmet"
+		mesh="sturgia_helmet_l"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="41"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_goggled_helmet_over_mail"
+		name="{=qc0P0b2r}Goggled Helmet over Mail"
+		mesh="sturgia_helmet_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_lendman_helmet_over_full_mail"
+		name="{=RTIzskq1}Lendman Helmet over Full Mail"
+		mesh="sturgia_helmet_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="39"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ironlame_feathered_spangenhelm"
+		name="{=YUWhHQmz}Ironlame Feathered Spangenhelm"
+		subtype="head_armor"
+		mesh="empire_helmet_i"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="34"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ironlame_feathered_spangenhelm_over_mail"
+		name="{=inYBaDwu}Iron Feathered Spangenhelm over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_i_fb"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_feathered_spangenhelm_over_imperial_coif"
+		name="{=QtuZSbG9}Feathered Spangenhelm over Coif"
+		subtype="head_armor"
+		mesh="empire_helmet_i_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="33"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_spangenhelm_with_leather"
+		name="{=3Z91Nxbf}Spangenhelm with Leather"
+		subtype="head_armor"
+		mesh="spangenhelm_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="15"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasalhelm_over_leather"
+		name="{=ONaWEKSy}Nasalhelm over Leather"
+		mesh="sturgia_helmet_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_with_leather"
+		name="{=TxAYmCjr}Nasal Helmet with Leather"
+		subtype="head_armor"
+		mesh="nasal_helmet_neckguard"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lord_helmet_a"
+		name="{=Oyeu738O}Northlander Lord Helmet"
+		mesh="sturgian_lord_helmet_a"
+		culture="Culture.sturgia"
+		subtype="head_armor"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_with_mail"
+		name="{=EWR2MNeM}Nasal Helmet with Mail"
+		subtype="head_armor"
+		mesh="nasal_helmet_reinforced"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		difficulty="0"
+		appearance="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_full_helm_over_cloth_headwrap"
+		name="{=SYvBTD0p}Full Helm over Cloth Headwrap"
+		mesh="vlandia_helmet_s_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="28"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_full_helm_over_arming_coif"
+		name="{=WYytQbvS}Full Helm over Arming Coif"
+		mesh="vlandia_helmet_s_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="26"
+				has_gender_variations="false"
+				hair_cover_type="type4"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_full_helm_over_padded_cap"
+		name="{=qVj5NqrL}Full Helm over Padded Cap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_s_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.8"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="48"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_full_helm_over_laced_coif"
+		name="{=wEfZyccm}Full Helm over Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_s_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="30"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Shoulder Armors -->
+	<!-- #region NeutralCulture Light Shoulder Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_hood"
+		name="{=lbVB6KPl}Hood"
+		culture="Culture.neutral_culture"
+		mesh="shoulder_cape_multicolor"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_peasant_hood"
+		name="{=lbVB6KPl}Hood"
+		culture="Culture.neutral_culture"
+		mesh="shoulder_cape_multicolor"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_scarf"
+		name="{=GNdVXMue}Scarf"
+		mesh="sturgia_cape_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_leather_shoulders"
+		name="{=Bl72Ribb}Padded Leather Shoulders"
+		mesh="shoulder_padding"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_imperial_neckguard"
+		name="{=ykCJ3hDB}Studded Neckguard"
+		mesh="empire_plate_armor_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="13"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wolf_shoulder"
+		name="{=YEUFtX4G}Wolf Shoulder"
+		mesh="wolf_shoulder"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_lamellar_shoulders"
+		name="{=Lt8nT1hb}Lamellar Shoulders"
+		mesh="imperial_shoulders"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="13"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_studded_shoulders"
+		name="{=I1ZBVhON}Steppe Studded Shoulders"
+		mesh="khuzait_leather_shoulder_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_leather_pauldron"
+		name="{=p2gPB04v}Steppe Leather Pauldron"
+		mesh="khuzait_leather_pauldron"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wrapped_scarf"
+		name="{=UxTD6XGA}Wrapped Scarf"
+		mesh="aserai_shoulder_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_leather_shoulderpad"
+		name="{=gfvG04SP}Desert Leather Shoulderpad"
+		mesh="aserai_bigchain_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horseman_shoulder"
+		name="{=mStaaxFF}Desert Ringmail Shoulder"
+		mesh="aserai_horseman_shoulder"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_stitched_leather_shoulders"
+		name="{=WrwO8xsN}Stitched Leather Shoulders"
+		mesh="aserai_plated_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leopard_pelt"
+		name="{=QxzcuhmA}Leopard Pelt"
+		mesh="leopard_pelt"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.0"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="9"
+				arm_armor="5"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bearskin"
+		name="{=4Q4JVfuT}Bearskin"
+		subtype="body_armor"
+		mesh="battania_helmet_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				arm_armor="4"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_cloak"
+		name="{=0Pxq8UqX}Highland Cloak"
+		mesh="battania_cloak"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_shoulder_furr"
+		name="{=cwC8Jp99}Highland Shoulder Furr"
+		mesh="battania_shoulder_furr"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_woodland_cloak"
+		name="{=Wo5RbJia}Highland Woodland Cloak"
+		mesh="battania_woodland_cloak"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_shoulder_strap_cloak"
+		name="{=TmJubG8W}Battania Shoulder Strap Cloak"
+		mesh="battania_shoulder_strap_cloak"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_cloak_furr"
+		name="{=mTsEaNKb}Fur Cloak"
+		mesh="battania_cloak_furr"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_pauldron_cape_a"
+		name="{=3qF14kaR}Empire Pauldron Cape"
+		mesh="pauldron_cape_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_pauldron_cape_b"
+		name="{=Q2F2uqRE}Vlandian Pauldron Cape"
+		mesh="pauldron_cape_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_lamellar_shoulders"
+		name="{=tKODIU0F}Leather Lamellar Shoulders"
+		mesh="leather_lamellar_armor_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="8"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_leather_shoulders"
+		name="{=4a99jSHC}Steppe Leather Shoulders"
+		mesh="khuzait_leather_armor_shoulder"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_suede_shoulders"
+		name="{=y9uMjAKT}Reinforced Suede Shoulders"
+		mesh="khuzait_suede_leather_shoulder"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_green_hood"
+		name="{=UvOa4elc}Green Hood"
+		mesh="shoulder_cape_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_civil_cape"
+		name="{=Vdi0vZV7}Highland Cape"
+		subtype="body_armor"
+		mesh="battania_civil_cape"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture"
+		weight="4"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_leather_shoulder_a"
+		name="{=ICsecuVv}Cured Leather Shoulder Pieces"
+		subtype="body_armor"
+		mesh="battanian_leather_shoulder_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		appearance="1.8"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_a_battania_cloak_a"
+		name="{=Jm3AiUo3}Simple Cape"
+		mesh="battania_cloak_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		appearance="1"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="1"
+				arm_armor="1"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Medium Shoulder Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_chainmail_shoulder_b"
+		name="{=qdMP2qWG}Mail Shoulder Reinforcements"
+		subtype="body_armor"
+		mesh="battanian_chainmail_shoulder_b"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="4.5"
+		difficulty="0"
+		appearance="1.8"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_chainmail_shoulder_a"
+		name="{=M0n609ut}Mail Shoulder Pieces"
+		subtype="body_armor"
+		mesh="battanian_chainmail_shoulder_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="4.5"
+		difficulty="0"
+		appearance="1.8"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_studded_strip_shoulders"
+		name="{=QcCC59DA}Studded Strip Shoulders"
+		mesh="empire_plated_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.1"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="14"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_a_aserai_scale_b_shoulder_d"
+		name="{=SIdCIRfG}Brass Scale Pauldrons"
+		mesh="aserai_scale_b_shoulder_d"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		appearance="3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				arm_armor="7"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_shoulder"
+		name="{=xn5CfwON}Padded Warrior Shoulders"
+		mesh="empire_warrior_padded_armor_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_lamellar_shoulders"
+		name="{=Lt8nT1hb}Lamellar Shoulders"
+		mesh="metal_lamellar_armor_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5.0"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_brass_lamellar_shoulder"
+		name="{=INWSxn7C}Bronze Lamellar Shoulders"
+		mesh="brass_lamellar_shoulder"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5.0"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="14"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_brass_lamellar_shoulder_white"
+		name="{=8frVbv2b}Northlander Lamellar Shoulders"
+		mesh="brass_lamellar_shoulder_white"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="5.0"
+		appearance="2"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="16"
+				arm_armor="6"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_warlord_pauldrons"
+		name="{=Ldqb9oAF}Highland Warlord Pauldrons"
+		mesh="battania_warlord_pauldrons"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="4.0"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="13"
+				arm_armor="13"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_civil_cloak"
+		name="{=0Pxq8UqX}Highland Cloak"
+		mesh="battania_civil_cloak"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="body_armor"
+		weight="4.0"
+		difficulty="0"
+		appearance="0.7"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="13"
+				arm_armor="13"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_armored_bearskin"
+		name="{=FOx5vZSJ}Armored Bearskin"
+		subtype="body_armor"
+		mesh="battania_helmet_j"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Body Armors -->
+	<!-- #region NeutralCulture Light Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_civil_a"
+		name="{=l5JDrvbW}Tartan Tunic"
+		mesh="battania_civil_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		appearance="0.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="1"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_civil_b"
+		name="{=qH5VV8In}Villager Leather Tunic"
+		mesh="battania_civil_b"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_civil_c"
+		name="{=dVekhkIU}Fur Coat over Tunic"
+		mesh="battania_civil_c"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_guards_kettle_over_padded_coif"
+		name="{=YQd9C8u2}Kettle over Padded Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_j_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="22"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_over_padded_cloth"
+		name="{=VcbEaV7T}Kettle Helmet over Padded Cloth"
+		subtype="head_armor"
+		mesh="vlandia_helmet_h_y"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="19"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bandit_envelope_dress_v1"
+		name="{=L0aYVd65}Commoner Tunic"
+		mesh="bandit_envelope_dress_v1"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="false"
+				body_mesh_type="shoulders"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tundra_tunic"
+		name="{=2u4RneKh}Northlander Belted Tunic"
+		subtype="body_armor"
+		mesh="fur_vaegir_b"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.3"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="9"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bandit_envelope_dress_v2"
+		name="{=qILO0HdK}Sleeveless Enveloped Padded Garments"
+		mesh="bandit_envelope_dress_v2"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="1"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_thick_sleeved_robe"
+		name="{=MKT5IzWm}Thick Sleeved Robe"
+		mesh="aserai_robe_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="6.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="1"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_layered_robe"
+		name="{=fk42FxCE}Layered Robe"
+		mesh="aserai_robe_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="14"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="3"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_hemp_tunic"
+		name="{=yTWOMSmv}Hemp Tunic"
+		mesh="armor_hemp_tunic"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		subtype="body_armor"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="1"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_long_hemp_tunic"
+		name="{=NUHzapSv}Long Hemp Tunic"
+		mesh="casual_01"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="4"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_leather_vest"
+		name="{=C8bVbM65}Tunic with Leather Vest"
+		mesh="sturgia_costume_m"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="8.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="0"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_f"
+		name="{=GTaxqBcv}Auxiliary Armor"
+		mesh="empire_warrior_padded_armor_f"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.9"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				leg_armor="6"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_savage_armor"
+		name="{=Jt0Mcn4D}Savage Armor"
+		subtype="body_armor"
+		mesh="battanian_savage_armor"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		difficulty="0"
+		appearance="0.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="10"
+				leg_armor="6"
+				arm_armor="3"
+				has_gender_variations="false"
+				covers_body="false"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			DoesNotHideChest="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_g"
+		name="{=T2POVRtg}Auxiliary Armor with Straps"
+		mesh="empire_warrior_padded_armor_g"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="2.0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				leg_armor="5"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_padded_cloth"
+		name="{=WLJOnehi}Reinforced Thick Tunic"
+		mesh="sturgia_costume_l"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="21"
+				leg_armor="5"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_baggy_trunks"
+		name="{=IH9GsYzv}Baggy Trousers"
+		mesh="bandit_1_a"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="4"
+				covers_body="false"
+				has_gender_variations="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			DoesNotHideChest="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_waistcoat_over_tunic"
+		name="{=XH9f3yOX}Fur Waistcoat over Tunic"
+		subtype="body_armor"
+		mesh="fur_vaegir_short"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="2.3"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_fortified_armor"
+		name="{=KVG0Tzaa}Reinforced Mirror Armor"
+		mesh="khuzait_fortified_armor"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_sturdy_armor"
+		name="{=e0SDWwmU}Sturdy Steppe Armor"
+		mesh="khuzait_sturdy_armor"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sleeveless_studded_fur_armor"
+		name="{=4AfHO0BA}Sleeveless Studded Fur Armor"
+		mesh="bandit_1_c"
+		subtype="body_armor"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				leg_armor="3"
+				arm_armor="0"
+				covers_body="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		id="mp_aserai_civil_b"
+		name="{=v4THTk5O}Kaftan with Leather Belt"
+		mesh="aserai_civil_b"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_civil_e"
+		name="{=FAPHmzxQ}Thawb"
+		mesh="aserai_civil_e"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="1"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_civil_c"
+		name="{=CBUdkmIw}Colored Kaftan"
+		mesh="aserai_civil_c"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_armor_with_strap"
+		name="{=eWf7bFGo}Fur Armor with Strap"
+		mesh="pict_armor_b"
+		subtype="body_armor"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		difficulty="0"
+		appearance="0.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="2"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tied_cloth_tunic"
+		name="{=MQ8LCvCE}Tied Cloth Tunic"
+		mesh="roman_cloth_tunic_a"
+		culture="Culture.empire"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="1"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		id="mp_khuzait_belt_leather"
+		name="{=4B2i8oxo}Coat with Mirrored Belt"
+		mesh="khuzait_belt_leather"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_rough_fur_over_chain"
+		name="{=KIxX6dH2}Rough Fur over Chain"
+		mesh="bandit_3_b"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="12.0"
+		appearance="0.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="30"
+				leg_armor="11"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_padded_leather_overcoat"
+		name="{=CtJPuRDa}Padded Leather Overcoat"
+		mesh="bandit_10"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="13"
+				leg_armor="7"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_burlap_sack_dress"
+		name="{=IuD9SaQM}Burlap Dress"
+		mesh="burlap_sack_dress"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="1"
+				leg_armor="1"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_cloth_tunic"
+		name="{=OJIRIm4j}Simple Cloth Tunic"
+		mesh="clothing_a"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		subtype="body_armor"
+		weight="0.4"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="1"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_long_fur_coat"
+		name="{=VbAHQ1BS}Long Fur Coat"
+		mesh="pict_armor_long_furry"
+		subtype="body_armor"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="2.6"
+		difficulty="0"
+		appearance="0.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="6"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sleeveless_fur_coat"
+		name="{=1cYka5tR}Sleeveless Fur Coat"
+		mesh="fur_vaegir_waistcoat"
+		subtype="body_armor"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="1"
+				arm_armor="0"
+				covers_body="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_armored_baggy_trunks"
+		name="{=lPeLZge5}Armored Baggy Trousers"
+		mesh="bandit_1_b"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="4"
+				covers_body="false"
+				has_gender_variations="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			DoesNotHideChest="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roughcloth_shortcoat"
+		name="{=hXijcZyp}Roughcloth Shortcoat"
+		mesh="walker_costume_a"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9.0"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				leg_armor="3"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_nordic_coat"
+		name="{=h5IlkYck}Heavy Coat"
+		subtype="body_armor"
+		mesh="sturgia_costume_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="14"
+				leg_armor="3"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_nordic_tunic"
+		name="{=CAO0bycV}Heavy Tunic"
+		mesh="sturgia_costume_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="0"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_tunic"
+		name="{=9aehD627}Luxury Tunic"
+		subtype="body_armor"
+		mesh="sturgia_costume_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="9"
+				leg_armor="0"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_tunic"
+		name="{=ZqTFQeai}Leather Tunic"
+		mesh="leather_tunic"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		appearance="1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_layered_leather_tunic"
+		name="{=4KYF5iCd}Layered Leather Tunic"
+		mesh="leather_tunic_2"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="6"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_highland_cloth"
+		name="{=j1pFE61w}Woodland Cloth Armor"
+		subtype="body_armor"
+		mesh="battania_cloth_armor_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="6"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_armor"
+		name="{=VSMpadvq}Fur Armor"
+		subtype="body_armor"
+		mesh="battania_fur_armor_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="13.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				leg_armor="2"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_robe"
+		name="{=bKBa7ahF}Long Simple Robe"
+		subtype="body_armor"
+		mesh="aserai_tunic_long"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_long_desert_robe"
+		name="{=DnhVJl4d}Long Desert Robe"
+		mesh="aserai_tunic_long"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="10"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				leg_armor="1"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_burlap_waistcoat"
+		name="{=mkoMUmLh}Burlap Waistcoat"
+		mesh="walker_costume_c"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="2"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_skirt"
+		name="{=Z9RlnXrD}Fur Skirt"
+		subtype="body_armor"
+		mesh="fur_vaegir_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="3"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ragged_robes"
+		name="{=tVyuxl8e}Ragged Robes"
+		mesh="sneak_costume"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="2"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bandit_leather_water_flask"
+		name="{=8hDoWBIa}Commoner Shirt"
+		mesh="bandit_leather_water_flask"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="false"
+				body_mesh_type="shoulders"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_bandit_c"
+		name="{=hELN8VXv}Torn Robe"
+		mesh="vlandia_bandit_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="23"
+				leg_armor="10"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_footmans_tunic"
+		name="{=2AcfBbCR}Military Tunic"
+		mesh="armor_roman_military_tunic"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				leg_armor="3"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tunic_with_shoulder_pads"
+		name="{=y3oIzUEp}Tunic with Shoulder Pads"
+		mesh="roman_cloth_tunic_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="13"
+				leg_armor="4"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_armor"
+		name="{=xQUi0F0k}Striped Coat"
+		mesh="armor_hun_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="14"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="2"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_khuzait_leather_stitched"
+		name="{=wD3Yuvfc}Steppe Stitched Leather"
+		mesh="khuzait_leather_stitch_a"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_robe"
+		name="{=HVJ9ax8Z}Steppe Robe"
+		mesh="mongol_cloth_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="14"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="9"
+				leg_armor="4"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_padded_cloth"
+		name="{=vCywYDmp}Light Padded Armor"
+		subtype="body_armor"
+		mesh="sturgia_costume_g"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="22"
+				leg_armor="7"
+				arm_armor="5"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bandit_gambeson"
+		name="{=bTUGfbH5}Rugged Gambeson"
+		mesh="bandit_gambeson"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		difficulty="0"
+		appearance="0.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="14"
+				leg_armor="7"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_padded_gambeson"
+		name="{=fwxHsC1h}Short Gambeson over Tunic"
+		mesh="sturgia_costume_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				leg_armor="6"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_bandit_a"
+		name="{=AobNdBBU}Cheap Paddings"
+		mesh="vlandia_bandit_a"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="2.9"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="10"
+				leg_armor="2"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_stitched_leather_vest"
+		name="{=xa7KRSCy}Stitched Leather Vest"
+		mesh="armor_leather_chain_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="10.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				leg_armor="7"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sleeveless_padded_short_coat"
+		name="{=bz5lXkHS}Sleeveless Padded Short Coat"
+		mesh="padded_coat_d"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="11.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				leg_armor="6"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_coat"
+		name="{=QbfOXJas}Padded Footman Coat"
+		subtype="body_armor"
+		mesh="padded_coat_a"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sleeveless_padded_coat"
+		name="{=lZ93DOrn}Sleeveless Padded Coat"
+		subtype="body_armor"
+		mesh="padded_coat_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sackcloth_tunic"
+		name="{=smKogclC}Sackcloth Tunic"
+		mesh="walker_costume_d"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_civil_a"
+		name="{=HXNb6Cqz}Luxury Kaftan with Waistband"
+		mesh="aserai_civil_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Medium Body Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_mail_over_leather"
+		name="{=l5PPS5lG}Infantryman Mail over Leather"
+		mesh="empire_armor_c"
+		culture="Culture.neutral_culture"
+		weight="8.6"
+		value="1"
+		is_merchandise="false"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="28"
+				leg_armor="7"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_e"
+		name="{=1BXuUR3s}Infantryman Long Gambeson"
+		mesh="empire_warrior_padded_armor_e"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="9"
+				leg_armor="5"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plated_leather_coat"
+		name="{=OvlG2Vu1}Rough Brigandine"
+		subtype="body_armor"
+		mesh="cop_a"
+		culture="Culture.neutral_culture"
+		weight="10.7"
+		value="1"
+		is_merchandise="false"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_legionary_mail"
+		name="{=PTKyNh2O}Legionary Mail"
+		mesh="empire_armor_b"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		weight="9.5"
+		value="1"
+		is_merchandise="false"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="7"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_woodland_outfit"
+		name="{=46orXtt0}Woodland Garments"
+		subtype="body_armor"
+		mesh="battania_woodland_outfit"
+		culture="Culture.neutral_culture"
+		weight="1.2"
+		value="1"
+		is_merchandise="false"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_short_coat"
+		name="{=4pqIsPhp}Padded Short Coat"
+		mesh="padded_coat_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="27"
+				leg_armor="9"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_gambeson_b"
+		name="{=aQN4Dlx2}Heavy Aketon"
+		mesh="gambeson_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="10.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				leg_armor="7"
+				arm_armor="4"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_patched_gambeson"
+		name="{=Jhshwa48}Patched Gambeson"
+		mesh="bandit_4"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		difficulty="0"
+		appearance="0.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_woven_leather_vest"
+		name="{=LgftnHPs}Woven Leather Vest"
+		subtype="body_armor"
+		mesh="archers_leather_vest"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="13.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				leg_armor="9"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_long_woolen_tunic"
+		name="{=U8QfF3Gw}Long Woolen Tunic"
+		mesh="armor_woolen_tunic"
+		culture="Culture.vlandia"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_scale_armor"
+		name="{=PL5SG9hI}Leather Scale Armor"
+		mesh="vlandia_leather_scale_armor"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="8.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="5"
+				arm_armor="7"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tunic_with_rolled_cloth"
+		name="{=QaysED62}Tunic with Rolled Cloth"
+		mesh="armor_tunic_with_rolled_cloth"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="8.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				leg_armor="3"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_belted_leather_cuirass"
+		name="{=CLYcnUra}Belted Leather Cuirass"
+		mesh="bandit_11"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="22"
+				leg_armor="8"
+				arm_armor="5"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_crude_leather_armor"
+		name="{=j2IVY6G6}Crude Hide Armor"
+		mesh="bandit_5"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="20"
+				leg_armor="5"
+				arm_armor="5"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_khuzait_lamellar_strapped"
+		name="{=jimBaHvz}Reinforced Leather Armor"
+		mesh="khuzait_lamellar_strap"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="7.3"
+		appearance="0.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="24"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_suede_armor"
+		name="{=XU9WgcIO}Reinforced Suede Armor"
+		subtype="body_armor"
+		mesh="khuzait_suede_leather"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_silk_clothing"
+		name="{=XiwTesky}Silk Kaftan"
+		mesh="aserai_crowd_costume"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="11.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="14"
+				leg_armor="0"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_leather_coat"
+		name="{=XkL1Re8b}Studded Leather Coat"
+		mesh="bandit_leather_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="10.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				leg_armor="7"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_light_armor"
+		name="{=!}mp_light_armor"
+		mesh="roman_cloth_tunic_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="1.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="18"
+				arm_armor="18"
+				head_armor="18"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_mercenary_armor"
+		name="{=sAml91Z3}Luxury Brigandine"
+		subtype="body_armor"
+		mesh="battania_mercenary_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="18.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="38"
+				leg_armor="16"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_robe_c_chain"
+		name="{=JW1mE68R}Layered Desert Robe"
+		mesh="aserai_robe_c_chain"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="24.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="22"
+				leg_armor="7"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_short_padded_robe"
+		name="{=QzAvlan7}Short Padded Robe"
+		subtype="body_armor"
+		mesh="sarranid_gambeson_v3"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="21.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="5"
+				arm_armor="2"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_long_padded_robe"
+		name="{=0SsLGsXk}Long Padded Robe"
+		mesh="sarranid_gambeson_v2"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="22.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="22"
+				leg_armor="7"
+				arm_armor="3"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_padded_cloth"
+		name="{=wWqavjat}Light Long Padded Armor"
+		mesh="aserai_fabric_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="7.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				leg_armor="7"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ringed_desert_armor"
+		name="{=7EAEIUIY}Heavy Ring Mail"
+		mesh="aserai_bigchain_armor"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="10.5"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				leg_armor="11"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_woodland_chainmail"
+		name="{=CcWpkREW}Heavy Mail Shirt with Wide Belt"
+		subtype="body_armor"
+		mesh="battania_woodland_chainmail"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="23"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="36"
+				leg_armor="15"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ranger_mail"
+		name="{=HKRGEXqy}Ranger Mail"
+		mesh="armor_pict_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="25"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="20"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_bandit_fur_b"
+		name="{=8nuXQ9F9}Fur Coat"
+		mesh="bandit_fur_b"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="1"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="0"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		id="mp_rough_fur_armor"
+		name="{=qo8hwDNU}Rough Fur Armor"
+		mesh="bandit_3_a"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="3.3"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="11"
+				leg_armor="4"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_scale_armor"
+		name="{=4eOHPops}Rugged Scale Armor"
+		subtype="body_armor"
+		mesh="battania_scale_armor_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="8.7"
+		difficulty="0"
+		appearance="0.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				leg_armor="1"
+				arm_armor="0"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_a"
+		name="{=bYxnCJjq}Infantryman Gambeson"
+		mesh="empire_warrior_padded_armor_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="13.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="9"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_b"
+		name="{=XNQPPIaA}Infantryman Gambeson over Leather Jacket"
+		mesh="empire_warrior_padded_armor_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="15.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="9"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_sloven_leather"
+		name="{=Csfcw8G7}Sloven Leather"
+		mesh="nordic_sloven_c"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="2.9"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="12"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_sloven_over_mail"
+		name="{=6XxiMU52}Leather Tabard over Mail"
+		mesh="nordic_sloven_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="21.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="13"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_decorated_nordic_hauberk"
+		name="{=bAidg8fV}Huscarl Decorated Mail Shirt"
+		subtype="body_armor"
+		mesh="sturgia_costume_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="20.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="34"
+				leg_armor="15"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_d"
+		name="{=CLTk2CMs}Infantryman Gambeson with Straps"
+		mesh="empire_warrior_padded_armor_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="9"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_studded_leather"
+		name="{=UHItyOQY}Steppe Studded Leather"
+		mesh="khuzait_leather_armor_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="14"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="27"
+				leg_armor="8"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_plated_leather"
+		name="{=FDEIHpIN}Mirrored Brigandine Armor"
+		mesh="plated_leather_armor_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="21.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="39"
+				leg_armor="15"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_lamellar_armor"
+		name="{=cjhhuTZD}Cured Leather Lamellar Armor"
+		mesh="leather_lamellar_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="14.0"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="31"
+				leg_armor="8"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_short_dress"
+		name="{=KdbHrcQx}Short Tunic"
+		mesh="empire_short_dress"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="0"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true"
+			DoesNotHideChest="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_strips_over_padded_robe"
+		name="{=iVataLxL}Leather Strips over Padded Robe"
+		lod_atlas_index="9"
+		subtype="body_armor"
+		mesh="sarranid_gambeson_v1"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="4.1"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="34"
+				leg_armor="9"
+				arm_armor="1"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_steppe_leather"
+		name="{=Qd0tQLpA}Studded Leather Armor"
+		subtype="body_armor"
+		mesh="khuzait_leather_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="14"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="21"
+				leg_armor="6"
+				arm_armor="3"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_over_cloth_headwrap"
+		name="{=olamAwhb}Nasal Helmet over Cloth Headwrap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_p_d"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		difficulty="0"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="all" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_over_mail"
+		name="{=tpQLvMSM}Nasal Helmet over Mail"
+		mesh="vlandia_helmet_p_v"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="3.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="42"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_leather_over_aketon"
+		name="{=dS4zm0UT}Studded Leather over Aketon"
+		mesh="crossbow_armor_leather"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="13.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="11"
+				arm_armor="6"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_stitched_leather_coat"
+		name="{=PeozdF9h}Stitched Cured Leather Coat"
+		mesh="khuzait_leather_plate"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="13.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="30"
+				leg_armor="12"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_leather_tabard"
+		name="{=0a6Vz7wi}Leather Tabard"
+		mesh="sturgia_leather_brass"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="20.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="20"
+				leg_armor="5"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aketon"
+		name="{=7b8Cwogx}Aketon"
+		mesh="crossbow_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="10"
+				leg_armor="6"
+				arm_armor="6"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_white_coat_over_mail"
+		name="{=YxglkaXU}White Tabard over Mail Hauberk"
+		subtype="body_armor"
+		mesh="templar_a_white"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="23.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="43"
+				leg_armor="18"
+				arm_armor="11"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_coat"
+		name="{=ZqTFQeai}Leather Tunic"
+		subtype="body_armor"
+		mesh="leather_coat"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="13.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="26"
+				leg_armor="9"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="false"
+		id="mp_leather_coat_over_cloth"
+		name="{=wKucIANJ}Leather Coat over Cloth"
+		mesh="walker_costume_b"
+		subtype="body_armor"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		difficulty="0"
+		appearance="0.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="17"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_leather_shirt"
+		name="{=tiTTWhpW}Padded Leather Shirt"
+		mesh="armor_roman_padded_leather_shirt"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="14.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="28"
+				leg_armor="8"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Heavy Body Armors -->
+	<Item
+		id="mp_desert_scale_armor"
+		name="{=VkRIefyW}Luxury Scale Armor"
+		lod_atlas_index="3"
+		mesh="aserai_scale_armor_b"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="14.4"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="32"
+				leg_armor="11"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_banded_leather_over_mail"
+		name="{=iAWzr8Q0}Banded Leather over Mail"
+		mesh="vlandia_leather_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="24.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="39"
+				leg_armor="17"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_western_scale_mail"
+		name="{=AJjEnCGN}Scale Mail"
+		mesh="vlandia_scale_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="27.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="43"
+				leg_armor="19"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_chainmail"
+		name="{=TziEtAIK}Vlandia Chainmail"
+		mesh="vlandia_chainmail_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="23"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="12"
+				arm_armor="4"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_shirt"
+		name="{=GzgUzrFY}Mail Shirt"
+		mesh="armor_roman_mail_shirt"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="22"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="35"
+				leg_armor="8"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fur_skirt_with_tunic"
+		name="{=qT6jIu3v}Fur Skirt with Tunic"
+		subtype="body_armor"
+		mesh="fur_vaegir_half_tunic"
+		culture="Culture.looters"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		difficulty="0"
+		appearance="0.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				leg_armor="3"
+				arm_armor="1"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_spiked_kettle_over_imperial_padding"
+		name="{=cjHygHb0}Spiked Kettle over Padding"
+		mesh="empire_helmet_k_b"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bearhead"
+		name="{=GXmDq2KR}Bear Head"
+		subtype="head_armor"
+		mesh="battania_helmet_g"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="16"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_helmet_over_padded_cap"
+		name="{=2qisE5ys}Kettle Helmet over Padded Cap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_h_e"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		appearance="0.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_helmet_with_metal_strips"
+		name="{=BlTREYCY}Guarded Lord Helmet"
+		mesh="empire_lord_helmet_c_2"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.7"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_pointed_skullcap_over_laced_coif"
+		name="{=6n44BIll}Pointed Skullcap over Laced Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_l_c"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="22"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_guarded_lord_helmet"
+		name="{=BlTREYCY}Guarded Lord Helmet"
+		mesh="empire_lord_helmet_b"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.7"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_nasalhelm_over_imperial_mail"
+		name="{=ISQ0cdOc}Heavy Nasalhelm over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_g_f"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		difficulty="0"
+		appearance="0.7"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="34"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leatherlame_nasalhelm_over_imperial_mail"
+		name="{=c1a5Pt8j}Bronze Nasalhelm over Mail"
+		mesh="empire_helmet_h_fa"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.7"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_nasalhelm_over_laced_cloth"
+		name="{=z6eTba5h}Heavy Nasalhelm over Laced Cloth"
+		mesh="empire_helmet_g_c"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.1"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="13"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_lord_helmet"
+		name="{=Ia7K4egV}Lordly Helmet"
+		mesh="empire_lord_helmet_a"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.5"
+		difficulty="0"
+		appearance="0.9"
+		Type="headArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type4"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_laced_cloth_coif"
+		name="{=kmdjRAoG}Laced Cloth Coif"
+		subtype="head_armor"
+		mesh="empire_helmet_c"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="4"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_coat_of_plates_over_mail"
+		name="{=PtfbqMeg}Brigandine over Mail"
+		mesh="tunic_ironplate_armor"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="25.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="45"
+				leg_armor="19"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_fortified_armor"
+		name="{=KwbnODoT}Brigandine over Hauberk"
+		subtype="body_armor"
+		mesh="sturgian_fortified_armor"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="28.6"
+		difficulty="0"
+		appearance="2.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="49"
+				leg_armor="25"
+				arm_armor="20"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_chainmail_armor_d"
+		name="{=WbjNNE8Z}Highland Reinforced Fian Mail"
+		subtype="body_armor"
+		mesh="battanian_chainmail_armor_d"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="16.6"
+		difficulty="0"
+		appearance="1.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="34"
+				leg_armor="8"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_chainmail_armor_c"
+		name="{=MTB2BunA}Highland Reinforced Mail over Tartan"
+		subtype="body_armor"
+		mesh="battanian_chainmail_armor_c"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="14.7"
+		difficulty="0"
+		appearance="1.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="32"
+				leg_armor="8"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_veteran_mercenary_armor"
+		name="{=EezWSI6v}Fortified Mercenary Armor"
+		subtype="body_armor"
+		mesh="veteran_mercenary_armor"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="8.2"
+		difficulty="0"
+		appearance="1.4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="24"
+				leg_armor="13"
+				arm_armor="12"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_armor_02"
+		name="{=eDMDUUfw}Aserai Chain Mail"
+		lod_atlas_index="3"
+		mesh="aserai_armor_02"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="17.0"
+		appearance="2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="31"
+				leg_armor="14"
+				arm_armor="15"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_armor_02_b"
+		name="{=DyXDcO36}Aserai Decorated Chain Mail"
+		lod_atlas_index="3"
+		mesh="aserai_armor_02_b"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="18.0"
+		appearance="4"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="32"
+				leg_armor="14"
+				arm_armor="15"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_robes"
+		name="{=R45H8quo}Toga"
+		mesh="empire_outfit_a"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		appearance="1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="8"
+				leg_armor="3"
+				arm_armor="4"
+				has_gender_variations="false"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_hauberk"
+		name="{=FHakBPXw}Hauberk"
+		subtype="body_armor"
+		mesh="mail_hauberk"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="23.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="34"
+				leg_armor="12"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_cloth_with_strips"
+		name="{=JKRQ8RDA}Padded Cloth with Strips"
+		mesh="empire_armor_a"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		subtype="body_armor"
+		weight="2.2"
+		difficulty="0"
+		appearance="0.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="10"
+				leg_armor="11"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_warrior_padded_armor_c"
+		name="{=cEhDJAQp}Infantryman Gambeson with Skirts"
+		mesh="empire_warrior_padded_armor_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="9"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_fine_town_tunic"
+		name="{=vbPBXiPC}Rich Tunic"
+		mesh="casual_02"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		appearance="0.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_lamellar_over_leather"
+		name="{=x3lcf2Do}Luxury Lamellar Vest over Leather"
+		mesh="empire_plate_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="24"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="41"
+				leg_armor="14"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_hauberk"
+		name="{=1jX7yxSW}Huscarl Mail Shirt"
+		subtype="body_armor"
+		mesh="sturgia_costume_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="19.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="33"
+				leg_armor="12"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_coat_of_plates"
+		name="{=w4RuDABQ}Coat Of Plates"
+		mesh="sturgia_plate_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="21.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="45"
+				leg_armor="15"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_woven_leather_coat"
+		name="{=wE7RWmIF}Boarskin Leather Coat"
+		mesh="vlandia_leather_stripes"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="12.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="31"
+				leg_armor="11"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_mail_over_stripped_leather"
+		name="{=7566s7pt}Infantryman Mail over Stripped Leather"
+		mesh="empire_armor_d"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="18.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="14"
+				arm_armor="3"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_chainmail_armor_a"
+		name="{=6fA31IxF}Heavy Mail Vest"
+		subtype="body_armor"
+		mesh="battanian_chainmail_armor_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="10.7"
+		difficulty="0"
+		appearance="1.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="28"
+				leg_armor="8"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_light_armor_c"
+		name="{=kaR27kWL}Highland Long Tartan"
+		subtype="body_armor"
+		mesh="battania_light_armor_c"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		difficulty="0"
+		appearance="1.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="7"
+				leg_armor="3"
+				arm_armor="0"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_scale_armor_on_cloth"
+		name="{=JbV0WoO7}Mastercrafted Southern Scale Mail"
+		lod_atlas_index="3"
+		mesh="aserai_scale_armor_on_cloth"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="18.0"
+		appearance="6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="35"
+				leg_armor="6"
+				arm_armor="7"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_legion_b"
+		name="{=7HbspP6x}Ornate Legionary Scale Mail"
+		mesh="empire_legion_b"
+		subtype="body_armor"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="28.0"
+		difficulty="0"
+		appearance="6.0"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="36"
+				leg_armor="18"
+				arm_armor="8"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_legion_a"
+		name="{=mBVCyRY5}Decorated Legionary Mail"
+		mesh="empire_legion_a"
+		subtype="body_armor"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="22.0"
+		difficulty="0"
+		appearance="5.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="30"
+				leg_armor="18"
+				arm_armor="8"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_light_armor_e"
+		name="{=yDykmlS7}Tartan Toga"
+		subtype="body_armor"
+		mesh="battania_light_armor_e"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		difficulty="0"
+		appearance="1.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				leg_armor="9"
+				arm_armor="0"
+				has_gender_variations="true"
+				covers_body="false"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			DoesNotHideChest="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_light_armor_d"
+		name="{=hab2DsOW}Highland Kilt over Tartan Trousers"
+		subtype="body_armor"
+		mesh="battania_light_armor_d"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		difficulty="0"
+		appearance="1.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				leg_armor="4"
+				arm_armor="0"
+				has_gender_variations="false"
+				covers_body="false"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			DoesNotHideChest="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_varangian_bra_basic"
+		name="{=564PHXk3}Decorated Leather Harness"
+		mesh="varangian_bra_basic"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		appearance="4"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				arm_armor="7"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_varangian_bra_royal"
+		name="{=RXDyumYz}Caped Leather Harness"
+		mesh="varangian_bra_royal"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		appearance="7"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				arm_armor="7"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_varangian_bra_padded"
+		name="{=qaKGuHSt}Decorated Leather Harness with Padding"
+		mesh="varangian_bra_padded"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		appearance="3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="10"
+				arm_armor="8"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_varangian_bra_scale"
+		name="{=eN1eFdhF}Decorated Leather Harness over Scale"
+		mesh="varangian_bra_scale"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="14"
+		appearance="6"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="19"
+				arm_armor="12"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_basic_imperial_leather_armor"
+		name="{=2BlJHSeu}Imperial Leather Armor"
+		mesh="empire_leather_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="29"
+				leg_armor="9"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_lamellar"
+		name="{=LMo6MaQS}Cataphract Lamellar Armor"
+		mesh="imperial_lamellar_a"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="22.1"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="43"
+				leg_armor="17"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_lamellar_armor"
+		name="{=tG1Q8r2u}Lancer Lamellar Armor"
+		mesh="metal_lamellar_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="20.3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="37"
+				leg_armor="16"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_plated_leather_vest"
+		name="{=BbhGL8XT}Brigandine Vest"
+		mesh="plated_leather_armor_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="25.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="36"
+				leg_armor="8"
+				arm_armor="2"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_brass_lamellar_over_mail"
+		name="{=CIDdPt1I}Bronze Lamellar over Mail"
+		mesh="brass_lamellar"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="22.5"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="44"
+				leg_armor="19"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_lamellar"
+		name="{=bAXuK5eG}Aserai Lamellar Armor"
+		subtype="body_armor"
+		mesh="aserai_cavalry_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="25.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="40"
+				leg_armor="10"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_archer_armor"
+		name="{=2cSOn9qb}Gambeson over Mail Armor"
+		subtype="body_armor"
+		mesh="aserai_archer_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="18.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="36"
+				leg_armor="14"
+				arm_armor="11"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horseman_armor"
+		name="{=NTaol1uQ}Ring Mail"
+		subtype="body_armor"
+		mesh="aserai_horseman"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="30"
+				leg_armor="8"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_stitched_leather_over_mail"
+		name="{=omLMiX89}Stitched Leather over Mail"
+		mesh="aserai_plated_skirt"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="23.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="43"
+				leg_armor="20"
+				arm_armor="7"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_robe_over_mail"
+		name="{=k71X3WNK}Robe over Mail Hauberk"
+		mesh="aserai_chain_tunic_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="18.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="33"
+				leg_armor="15"
+				arm_armor="4"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_skirt"
+		name="{=ys3kQM0R}Imperial Lamellar Armor"
+		mesh="imperial_lamellar_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="22.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="54"
+				leg_armor="54"
+				arm_armor="54"
+				head_armor="54"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_medium_skirt"
+		name="{=z7oMeRl3}Thick Brigandine Vest"
+		mesh="khuzait_leather_stitch_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="10.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="33"
+				leg_armor="33"
+				arm_armor="33"
+				head_armor="33"
+				covers_body="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_lamellar_vest"
+		name="{=luoXhz19}Heavy Lamellar Vest"
+		mesh="sturgia_costume_k"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="16.7"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="44"
+				leg_armor="12"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nordic_lamellar_armor"
+		name="{=abGJeb3q}Sturgian Lamellar Armor"
+		subtype="body_armor"
+		mesh="sturgia_costume_i"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="22.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="42"
+				leg_armor="13"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_noble_armor"
+		name="{=p9cQARqf}Highborn Mail Armor"
+		subtype="body_armor"
+		mesh="battania_noble_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="25"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="43"
+				leg_armor="18"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_chainmail_armor_b"
+		name="{=y3CwqUDR}Highland Mail Shirt"
+		subtype="body_armor"
+		mesh="battanian_chainmail_armor_b"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="10.7"
+		difficulty="0"
+		appearance="1.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="23"
+				leg_armor="4"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_warlord_armor"
+		name="{=erlrhK2a}Scale Warlord Armor"
+		subtype="body_armor"
+		mesh="battania_warlord_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="20.9"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="41"
+				leg_armor="16"
+				arm_armor="4"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_scale_armor"
+		name="{=VQSdhQE3}Heavy Scale Armor over Mail Hauberk"
+		mesh="imperial_lamellar_b"
+		subtype="body_armor"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="27.2"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="44"
+				leg_armor="18"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_lamellar_with_scale_skirt"
+		name="{=zGXZJFOb}Lamellar with Scale Skirt"
+		mesh="imperial_lamellar_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="26"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="45"
+				leg_armor="20"
+				arm_armor="11"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Arm Armors -->
+	<!-- #region NeutralCulture Light Arm Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_leather_vambraces"
+		name="{=CXnhFf1t}Reinforced Leather Vambraces"
+		mesh="crossbow_armor_leather_hand_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.3"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="11"
+				covers_hands="false"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_buttoned_leather_bracers"
+		name="{=iD0ePqi7}Buttoned Leather Bracers"
+		mesh="bandit_leather_wristbands"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="5"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_decorated_imperial_gauntlets"
+		name="{=2XEbqNQz}Decorated Imperial Gauntlets"
+		mesh="empire_plate_armor_gauntlets"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		appearance="0.9"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="29"
+				covers_hands="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_vambrace"
+		name="{=MamotK0a}Padded Vambraces"
+		mesh="padded_vambrace_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.1"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="2"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_gloves"
+		name="{=lIJ1EVBh}Leather Gloves"
+		mesh="crossbow_armor_hand"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="5"
+				covers_hands="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_mail_mitten"
+		name="{=dPQGxmJ7}Reinforced Mail Mittens"
+		mesh="mail_mitten_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		difficulty="0"
+		appearance="0.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="18"
+				covers_hands="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_mitten"
+		name="{=g51zVsKU}Mail Mittens"
+		mesh="mail_mitten_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="8"
+				covers_hands="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_padded_mitten"
+		name="{=PLtQdf23}Reinforced Padded Mittens"
+		mesh="padded_vambrace_a_reinforced"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		difficulty="0"
+		appearance="0.7"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="9"
+				covers_hands="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_mitten"
+		name="{=J3YHMkL3}Padded Mittens"
+		mesh="padded_vambrace_a_mitten"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		difficulty="0"
+		appearance="0.3"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="7"
+				covers_hands="true"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_woven_leather_bracers"
+		name="{=fUmehyHq}Woven Leather Bracers"
+		mesh="vlandia_leather_stripes_bracers"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="10"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_guarded_padded_vambrace"
+		name="{=whvMZZba}Guarded Padded Vambraces"
+		mesh="padded_vambrace_a_handguard"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="6"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_wrapped_armguards"
+		name="{=b2EDkbhD}Wrapped Armguards"
+		mesh="plated_leather_armor_glove_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="3"
+				covers_hands="false"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		id="mp_rough_tied_bracers"
+		name="{=uEPRE33m}Rough Tied Bracers"
+		mesh="bandit_3_wrist"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		appearance="0.3"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="4"
+				covers_hands="false"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_leather_vambraces"
+		name="{=bxa4JHlU}Studded Leather Vambraces"
+		mesh="crossbow_armor_leather_hand_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="10"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_leather_vambraces"
+		name="{=8DnJls9z}Steppe Leather Vambraces"
+		mesh="khuzait_leather_armor_hand"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="4"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_armwraps"
+		name="{=oEJnxsQ1}Armwraps"
+		mesh="battania_armwraps_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.2"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="2"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_vambraces"
+		name="{=8uBew3nD}Studded Vambraces"
+		mesh="bandit_1_wristband"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		difficulty="0"
+		appearance="0.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="9"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_highland_gloves"
+		name="{=4HcrY0S2}Fur Rimmed Leather Gloves"
+		mesh="pict_armor_glove"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="7"
+				covers_hands="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_guarded_armwraps"
+		name="{=a1BGHdaU}Guarded Armwraps"
+		mesh="battania_armwraps_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="3"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ragged_armwraps"
+		name="{=jIwjYOVj}Ragged Armwraps"
+		mesh="sneak_costume_hand"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="4"
+				covers_hands="false"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_noble_bracers"
+		name="{=DScCbmoS}Battania Noble Bracers"
+		mesh="battania_noble_bracers"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="10"
+				covers_hands="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Medium Arm Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_lordly_mail_mitten"
+		name="{=VDMkVMxt}Heavy Mail Mittens"
+		mesh="mail_mitten_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.7"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="19"
+				covers_hands="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_decorated_imperial_boots"
+		name="{=gXbmGrGL}Decorated Imperial Boots"
+		mesh="empire_plate_armor_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.3"
+		appearance="0.9"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="16"
+				covers_legs="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_brass_bracers"
+		name="{=Xrb43Fv4}Bronze Bracers"
+		mesh="sturgia_leather_brass_bracer"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.3"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="16"
+				covers_hands="false"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_plated_gloves"
+		name="{=G8FQ2exX}Plate Reinforced Gloves"
+		mesh="sturgia_plate_gauntlet"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="17"
+				covers_hands="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_lamellar_plate_gauntlets"
+		name="{=XGX6DbFL}Lamellar Plate Gauntlets"
+		mesh="imperial_gauntlets"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="20"
+				covers_hands="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_plated_leather_vambraces"
+		name="{=mvTueU1y}Plated Leather Vambraces"
+		mesh="plated_leather_armor_glove_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.7"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="18"
+				covers_hands="false"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_warlord_bracers"
+		name="{=I0vRCZ7U}Scale Warlord Bracers"
+		mesh="battania_warlord_bracers"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="18"
+				covers_hands="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plated_strip_gauntlets"
+		name="{=a3vHlztg}Plated Strip Gauntlets"
+		mesh="empire_plated_gauntlets"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="15"
+				covers_hands="false"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ironlame_roundkettle_over_imperial_mail"
+		name="{=XuwQvSDo}Iron Roundkettle over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_j_fb"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="2.85"
+		difficulty="0"
+		appearance="1.65"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ironlame_nasalhelm_over_imperial_mail"
+		name="{=DbavaIis}Iron Nasalhelm over Mail"
+		subtype="head_armor"
+		mesh="empire_helmet_h_fb"
+		culture="Culture.empire"
+		value="1"
+		is_merchandise="false"
+		weight="3.3"
+		appearance="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="48"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_helmet_with_mail"
+		name="{=Zo7jJbQj}Desert Helmet with Mail"
+		subtype="head_armor"
+		mesh="aserai_helmet_l"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.9"
+		difficulty="0"
+		appearance="0.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="22"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Leg Armors -->
+	<!-- #region NeutralCulture Light Leg Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_strapped_shoes"
+		name="{=LOPavWRp}Strapped Shoes"
+		mesh="strapped_shoes"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="4"
+				covers_legs="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_cavalier_boots"
+		name="{=oEvhhNNR}Leather Cavalier Boots"
+		mesh="cav_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="10"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_woven_leather_boots"
+		name="{=J00AF9Qv}Woven Leather Boots"
+		mesh="bandit_10_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.3"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="8"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_strapped_leather_boots"
+		name="{=tMwsE9IR}Strapped Leather Boots"
+		mesh="boot_g"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="5"
+				covers_legs="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_shoes"
+		name="{=Kgnm0FkE}Leather Shoes"
+		mesh="boot_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="3"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horseman_boots"
+		name="{=aR1Tl119}Courser Boots"
+		mesh="empire_horseman_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.4"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="9"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_leather_boots"
+		name="{=Tj1Zb47Q}Steppe Leather Boots"
+		mesh="khuzait_leather_armor_foot"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="7"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_eastern_leather_boots"
+		name="{=D9JrTpwU}Curved Boots"
+		mesh="plated_leather_armor_boot"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="11"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_suede_boots"
+		name="{=9Eyd2qGo}Reinforced Suede Boots"
+		mesh="khuzait_suede_leather_foot"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="9"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_curved_boots"
+		name="{=ZOa7p47T}Stapped Curved Boots"
+		mesh="khuzait_leather_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.1"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="10"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_leather_boots"
+		name="{=BLeQnEKZ}Leather Boots"
+		mesh="boot_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="7"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wrapped_shoes"
+		name="{=4YxbZlbi}Wrapped Shoes"
+		mesh="wrapped_shoes"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="4"
+				covers_legs="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_fine_town_boots"
+		name="{=uUGAMReu}Fine Town Boots"
+		mesh="casual_02_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="7"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_fur_boots"
+		name="{=vwVFF1XJ}Highland Fur Boots"
+		mesh="battania_fur_boot_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.5"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="12"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_rough_tied_boots"
+		name="{=Oo0baNaq}Rough Tied Boots"
+		mesh="bandit_3_boot"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.9"
+		appearance="0.1"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="9"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_highland_leg_wrappings"
+		name="{=cCaHNMwf}Highland Leg Wrappings"
+		mesh="battania_boot_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="6"
+				covers_legs="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_highland_boots"
+		name="{=42KNket2}Highland Boots"
+		mesh="pict_armor_boot"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="9"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wrapped_leather_boots"
+		name="{=WahziEXA}Wrapped Leather Boots"
+		mesh="bandit_leather_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="9"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_warlord_boots"
+		name="{=eTKxlDl1}Highland Warlord Boots"
+		mesh="battania_warlord_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.6"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="16"
+				covers_legs="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_woodland_boots"
+		name="{=SRZzySbP}Highland Woodland Boots"
+		mesh="battania_woodland_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="10"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<!-- #endregion -->
+	<!-- #region NeutralCulture Medium Leg Armors -->
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_cavalier_boots"
+		name="{=tWfAPrPa}Mail Cavalier Boots"
+		mesh="cav_boots_reinforced"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="15"
+				covers_legs="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_lamellar_plate_boots"
+		name="{=9cHyHQ7a}Lamellar Plate Boots"
+		mesh="imperial_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.5"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="20"
+				covers_legs="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_plated_boots"
+		name="{=ms4AKynl}Plated Boots"
+		mesh="sturgia_plate_boot"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.9"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="17"
+				covers_legs="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_strapped_mail_chausses"
+		name="{=aYoIrpe0}Strapped Mail Chausses"
+		mesh="mail_chausses_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.0"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="15"
+				covers_legs="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_leather_boots"
+		name="{=hTRaPvRa}Highland Leather Boots"
+		mesh="battania_leather_boots_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.5"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="11"
+				covers_legs="true"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_chausses"
+		name="{=DoiwC1Qa}Mail Chausses"
+		mesh="mail_chausses_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.9"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="13"
+				covers_legs="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_plated_strip_boots"
+		name="{=Fb7PrJuc}Splint Boots"
+		mesh="empire_plated_boots"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		Type="LegArmor">
+		<ItemComponent>
+			<Armor
+				leg_armor="14"
+				covers_legs="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Weapons -->
+	<!-- #region Axe -->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_hatchet_axe"
+		name="{=GghHAbIT}Hatchet"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_hatchet_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_hatchet_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_axe"
+		name="{=l2pEOHk6}Aserai Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_aserai_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_axe"
+		name="{=1yzNGUJH}Imperial Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_heavy_axe"
+		name="{=bZSQpada}Imperial Heavy Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_heavy_axe_head"
+				Type="Blade"
+				scale_factor="92" />
+			<Piece
+				id="mp_empire_heavy_axe_handle"
+				Type="Handle"
+				scale_factor="107" />
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 69 Weight: 1.29 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_battle_axe"
+		name="{=cQMDVJnE}Imperial Battle Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_battle_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_battle_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_billhook"
+		name="{=n21mBbbR}Bill"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_billhook_head"
+				Type="Blade"
+				scale_factor="104" />
+			<Piece
+				id="mp_vlandian_billhook_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_sickle"
+		name="{=4wdgiTta}Sickle"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_sickle_head"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_vlandia_sickle_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_long_twohandedaxe"
+		name="{=I8zNQS7i}Skoldern Twohanded Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_2haxe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_2haxe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_short_twohandedaxe"
+		name="{=CtzzoSBc}Short Skoldern Twohanded Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_short_2axe_head"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_short_2haxe_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_woodcutters_axe"
+		name="{=RGwcnlmQ}Two Handed Woodcutter Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_woodcutters_axe_head"
+				Type="Blade" />
+			<Piece
+				id="mp_battania_woodcutters_axe_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 7700 Weight: 1.18 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_twohanded_axe"
+		name="{=B8p6E8GJ}Tabar"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_2haxe_head"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_2haxe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_strong_twohanded_axe"
+		name="{=a8ycVmwU}Bardiche"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_strong_2haxe_head"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_strong_2haxe_handle"
+				Type="Handle"
+				scale_factor="105" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_axe"
+		name="{=btoJTO9G}Raider Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_axe_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_heavy_axe"
+		name="{=ITKKkoXI}Raider Heavy Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_heavy_axe_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_heavy_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_noble_axe"
+		name="{=ZzzUQjna}Noble Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_noble_axe_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_heavy_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_cavalry_axe"
+		name="{=HKPCngu0}Raider Cavalry Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_cavalry_axe_head"
+				Type="Blade" />
+			<Piece
+				id="mp_sturgia_cavalry_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_twohanded_axe"
+		name="{=HFIsOSHl}Raider Twohanded Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_2haxe_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_2haxe_handle"
+				Type="Handle"
+				scale_factor="95"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_long_twohanded_axe"
+		name="{=Mbf8qAxs}Long Twohanded Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_long_2haxe_head"
+				Type="Blade" />
+			<Piece
+				id="mp_sturgia_long_2haxe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_light_axe"
+		name="{=IbrLksih}Eastern Light Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_light_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_battle_axe_handle"
+				Type="Handle"
+				scale_factor="94" />
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 85 Weight: 1.03 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_sichel"
+		name="{=xW2NPgay}Eastern Sickle"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_sichel_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_khuzait_sichel_handle"
+				Type="Handle"
+				scale_factor="95" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_woodsplitter_axe"
+		name="{=aDEjwU8L}Woodsplitter Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturiga_woodsplitter_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturiga_woodsplitter_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_axe"
+		name="{=gXu0brD7}Vlandian Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_bastard_axe"
+		name="{=ZJweh5Oh}Bastard Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandia_bastard_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandia_bastard_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_axe"
+		name="{=aGxtOTB8}Highland Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_battania_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 6800 Weight: 1.3 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_pick_axe"
+		name="{=ZvMcHde3}Pickaxe"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_pick_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_pick_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 6800 Weight: 1.3 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_halberd_lol"
+		name="{=bzCoIgk7}Military Bill"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandia_halberd_head"
+				Type="Blade"
+				scale_factor="107" />
+			<Piece
+				id="mp_vlandia_halberd_handle"
+				Type="Handle"
+				scale_factor="105" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_axe"
+		name="{=RtlqkbZ9}MP Test Axe"
+		crafting_template="OneHandedAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_test_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_test_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_twohandedaxe"
+		name="{=7R8r1WvR}MP Test 2h Axe"
+		crafting_template="TwoHandedAxe"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_2haxe_head"
+				Type="Blade" />
+			<Piece
+				id="mp_test_2haxe_handle"
+				Type="Handle"
+				scale_factor="103" />
+		</Pieces>
+	</CraftedItem>
+	<!-- #endregion -->
+	<!-- #region Polearm -->
+	<Item
+		multiplayer_item="true"
+		id="push_fork"
+		name="{=l69aXkKH}Push Fork"
+		is_merchandise="false"
+		body_name="bo_push_fork"
+		recalculate_body="true"
+		mesh="push_fork"
+		subtype="two_handed_wpn"
+		weight="2"
+		difficulty="0"
+		appearance="0.1"
+		Type="Polearm"
+		item_holsters="polearm_back:polearm_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="TwoHandedPolearm"
+				weapon_balance="100"
+				thrust_speed="56"
+				speed_rating="70"
+				physics_material="wood_weapon"
+				weapon_length="200"
+				swing_damage="5"
+				thrust_damage="2"
+				swing_damage_type="Blunt"
+				thrust_damage_type="Blunt"
+				item_usage="polearm_block_thrust">
+				<WeaponFlags
+					MeleeWeapon="true"
+					PenaltyWithShield="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					WideGrip="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			DropOnWeaponChange="true"
+			DoNotScaleBodyAccordingToWeaponLength="true"
+			QuickFadeOut="true" />
+	</Item>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_polearm"
+		name="{=zbsajPMp}Voulge"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandia_polearm_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandia_polearm_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_menavlion"
+		name="{=7LmUe8fQ}Menavlion"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_menavlion_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_guard_3"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_menavlion_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 18700 Weight: 2.35 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_cavalry_menavlion"
+		name="{=sZsOeSQ4}Cavalry Menavlion"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_cavalry_menavlion_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_guard_3"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_cavalry_menavlion_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_long_menavlion"
+		name="{=acufJvyn}Long Menavlion"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_long_menavlion_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_guard_3"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_long_menavlion_handle"
+				Type="Handle"
+				scale_factor="95" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 18700 Weight: 2.35 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_heavy_menavlion"
+		name="{=bzr6vtXi}Heavy Menavlion"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_heavy_menavlion_blade"
+				Type="Blade"
+				scale_factor="104" />
+			<Piece
+				id="mp_spear_guard_6"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_heavy_menavlion_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 21400 Weight: 2.6 -->
+	</CraftedItem>
+	<CraftedItem
+		id="mp_empire_polearm"
+		name="{=dK4f8ArH}Imperial Polearm"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_empire_polearm_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_empire_polearm_handle"
+				Type="Handle"
+				scale_factor="109" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 11100 Weight: 1.38 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_glaive"
+		name="{=6hwZwODh}Glaive"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_glaive_blade"
+				Type="Blade"
+				scale_factor="96" />
+			<Piece
+				id="mp_khuzait_glaive_handle"
+				Type="Handle"
+				scale_factor="94" />
+		</Pieces>
+		<!-- Length: 143 Weight: 1.91 SwingSpeed: 66 ThrustSpeed: 98 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_heavy_glaive"
+		name="{=Bruzcqbm}Heavy Glaive"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_heavy_glaive_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_13"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_heavy_glaive_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 19400 Weight: 2.38 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_long_spear"
+		name="{=607BAdXw}Western Long Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_long_spear_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_spear_guard_6"
+				Type="Guard" />
+			<Piece
+				id="mp_western_long_spear_handle"
+				Type="Handle"
+				scale_factor="102" />
+			<Piece
+				id="mp_spear_pommel_7"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 18500 Weight: 1.99 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_cavalry_spear"
+		name="{=yf3zokFF}Western Cavalry Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_cavalry_spear_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_western_long_spear_handle"
+				Type="Handle"
+				scale_factor="109" />
+			<Piece
+				id="mp_spear_pommel_7"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 18500 Weight: 1.99 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_short_spear"
+		name="{=qFV7uqVW}Short Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_short_spear_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_western_spear_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_pommel_7"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 171 Weight: 1.97 SwingSpeed: 58 ThrustSpeed: 98 SwingDamage: 26B, 0S ThrustDamage: 11B, 41S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_spear"
+		name="{=9XhksMzN}Western Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_1"
+				Type="Guard" />
+			<Piece
+				id="mp_western_spear_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_pommel_7"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 171 Weight: 1.97 SwingSpeed: 58 ThrustSpeed: 98 SwingDamage: 26B, 0S ThrustDamage: 11B, 41S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_pitchfork_metal"
+		name="{=EpkGO9qE}Metal Pitchfork"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_pitchfork_metal_blade"
+				Type="Blade"
+				scale_factor="105" />
+			<Piece
+				id="mp_western_pitchfork_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 171 Weight: 1.97 SwingSpeed: 58 ThrustSpeed: 98 SwingDamage: 26B, 0S ThrustDamage: 11B, 41S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_pitchfork_wood"
+		name="{=JBVAeXx3}Pitchfork"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_pitchfork_wood_blade"
+				Type="Blade"
+				scale_factor="105" />
+			<Piece
+				id="mp_western_pitchfork_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_scythe"
+		name="{=aGbTPme1}Scythe"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_western_scythe_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_polearm_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 117 Weight: 3.7 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_2h_sickle"
+		name="{=IPp2QGwE}Hay Sickle"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_western_2h_sickle_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_polearm_handle"
+				Type="Handle"
+				scale_factor="95" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 117 Weight: 3.7 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_2h_shovel"
+		name="{=UCvfcokJ}Shovel"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_western_shovel_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_polearm_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 117 Weight: 3.7 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_pike"
+		name="{=BwOZwFxm}Aserai Pike"
+		crafting_template="Pike"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_pike_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_11"
+				Type="Guard" />
+			<Piece
+				id="mp_aserai_pike_handle"
+				Type="Handle"
+				scale_factor="98" />
+		</Pieces>
+		<!-- Length: 276 Weight: 2.52 SwingSpeed: 24 ThrustSpeed: 93 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_pike"
+		name="{=iNJr5HOM}Awl Pike"
+		crafting_template="Pike"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_pike_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_11"
+				Type="Guard" />
+			<Piece
+				id="mp_vlandian_pike_handle"
+				Type="Handle"
+				scale_factor="98" />
+		</Pieces>
+		<!-- Length: 276 Weight: 2.52 SwingSpeed: 24 ThrustSpeed: 93 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_spear"
+		name="{=s03kaATW}Khuzait Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_spear_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_guard_15"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_khuzait_spear_handle"
+				Type="Handle"
+				scale_factor="108" />
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 177 Weight: 1.97 SwingSpeed: 57 ThrustSpeed: 98 SwingDamage: 26B, 0S ThrustDamage: 11B, 41S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_short_spear"
+		name="{=rLFdje27}Khuzait Short Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_short_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_18"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_short_spear_handle"
+				Type="Handle"
+				scale_factor="105" />
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 12400 Weight: 1.44 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_long_spear"
+		name="{=uxVG86DF}Khuzait Long Spear"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_long_spear_blade"
+				Type="Blade"
+				scale_factor="103" />
+			<Piece
+				id="mp_spear_guard_1"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_long_spear_handle"
+				Type="Handle" />
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 207 Weight: 2.06 SwingSpeed: 49 ThrustSpeed: 97 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_long_infantry_spear"
+		name="{=mFM5jUuF}Khuzait Long Infantry Spear"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_long_infantry_spear_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_spear_guard_13"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_long_spear_handle"
+				Type="Handle" />
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_cavalry_spear"
+		name="{=ztgczd7L}Khuzait Cavalry Spear"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_cavalry_spear_blade"
+				Type="Blade"
+				scale_factor="101" />
+			<Piece
+				id="mp_spear_guard_14"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_khuzait_long_spear_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_pommel_12"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 207 Weight: 2.06 SwingSpeed: 49 ThrustSpeed: 97 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_pike"
+		name="{=XzoyPCvS}Khuzait Pike"
+		crafting_template="Pike"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_pike_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_vlandian_pike_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 198 Weight: 2.08 SwingSpeed: 55 ThrustSpeed: 97 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_pike"
+		name="{=1aotLA6v}Highland Pike"
+		crafting_template="Pike"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_pike_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_guard_2"
+				Type="Guard" />
+			<Piece
+				id="mp_vlandian_pike_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 19200 Weight: 2.12 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_spear"
+		name="{=inquCxkd}Aserai Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_13"
+				Type="Guard" />
+			<Piece
+				id="mp_aserai_spear_handle"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_pommel_11"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 177 Weight: 1.97 SwingSpeed: 57 ThrustSpeed: 98 SwingDamage: 26B, 0S ThrustDamage: 11B, 41S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_bamboo_spear"
+		name="{=RF7uVEGp}Bamboo Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_bamboo_spear_blade"
+				Type="Blade"
+				scale_factor="95" />
+			<Piece
+				id="mp_aserai_bamboo_spear_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_pommel_11"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 177 Weight: 1.97 SwingSpeed: 57 ThrustSpeed: 98 SwingDamage: 26B, 0S ThrustDamage: 11B, 41S -->
+	</CraftedItem>
+	<CraftedItem
+		id="mp_aserai_long_spear"
+		name="{=cEUqPott}Aserai Long Spear"
+		is_merchandise="false"
+		crafting_template="TwoHandedPolearm"
+		value="1">
+		<Pieces>
+			<Piece
+				id="mp_aserai_long_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_12"
+				Type="Guard" />
+			<Piece
+				id="mp_aserai_long_spear_handle"
+				Type="Handle"
+				scale_factor="107" />
+			<Piece
+				id="mp_spear_pommel_11"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 18200 Weight: 2.15 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_short_spear"
+		name="{=b5dkMbBp}Sturgian Short Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_short_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_4"
+				Type="Guard" />
+			<Piece
+				id="mp_sturgia_short_spear_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_pommel_10"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 157 Weight: 1.26 SwingSpeed: 72 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_spear"
+		name="{=b0pyML1S}Sturgian Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_spear_blade"
+				Type="Blade"></Piece>
+			<Piece
+				id="mp_spear_guard_5"
+				Type="Guard" />
+			<Piece
+				id="mp_sturgia_spear_handle"
+				Type="Handle"
+				scale_factor="100"></Piece>
+			<Piece
+				id="mp_spear_pommel_10"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 157 Weight: 1.26 SwingSpeed: 72 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_long_spear"
+		name="{=CEk1LX84}Sturgian Long Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_long_spear_blade"
+				Type="Blade"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_spear_guard_9"
+				Type="Guard" />
+			<Piece
+				id="mp_sturgia_long_spear_handle"
+				Type="Handle"
+				scale_factor="95"></Piece>
+			<Piece
+				id="mp_spear_pommel_10"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 211 Weight: 1.67 SwingSpeed: 53 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_long_infantry_spear"
+		name="{=aMB36bbl}Sturgian Long Infantry Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_long_infantry_spear_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_guard_11"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_sturgia_long_spear_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_pommel_10"
+				Type="Pommel" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_lance"
+		name="{=VEufDIXI}Western Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_lance_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_western_lance_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 232 Weight: 2.7 SwingSpeed: 36 ThrustSpeed: 91 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_long_lance"
+		name="{=NKZ0P4aU}Vlandian Long Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_western_long_lance_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_western_long_lance_handle"
+				Type="Handle"
+				scale_factor="109" />
+		</Pieces>
+		<!-- Length: 232 Weight: 2.7 SwingSpeed: 36 ThrustSpeed: 91 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_heavy_lance"
+		name="{=SGa04hNj}Vlandian Heavy Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_heavy_lance_blade"
+				Type="Blade"
+				scale_factor="95" />
+			<Piece
+				id="mp_vlandian_heavy_lance_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 232 Weight: 2.7 SwingSpeed: 36 ThrustSpeed: 91 -->
+	</CraftedItem>
+	<!--TODO-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_lance"
+		name="{=pyupZxJK}Kontos"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_lance_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_empire_lance_handle"
+				Type="Handle"
+				scale_factor="108" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 19600 Weight: 2.1 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_heavy_lance"
+		name="{=AO5LPmQf}Heavy Kontos"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_empire_heavy_lance_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_heavy_lance_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 217 Weight: 2.51 SwingSpeed: 40 ThrustSpeed: 93 SwingDamage: 23B, 0S ThrustDamage: 11B, 40S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_lance"
+		name="{=inr9Mt1i}Khuzait Lance"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_lance_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_khuzait_lance_handle"
+				Type="Handle"
+				scale_factor="103" />
+		</Pieces>
+		<!-- Length: 192 Weight: 2.15 SwingSpeed: 52 ThrustSpeed: 96 SwingDamage: 25B, 0S ThrustDamage: 11B, 40S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_lance_heavy"
+		name="{=inr9Mt1i}Khuzait Lance"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_lance_blade_heavy"
+				Type="Blade" />
+			<Piece
+				id="mp_khuzait_lance_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 192 Weight: 2.15 SwingSpeed: 52 ThrustSpeed: 96 SwingDamage: 25B, 0S ThrustDamage: 11B, 40S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_lance_long"
+		name="{=c6dK068V}Khuzait Long Lance"
+		crafting_template="TwoHandedPolearm"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_lance_blade"
+				Type="Blade"
+				scale_factor="106" />
+			<Piece
+				id="mp_spear_guard_14"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_lance_handle"
+				Type="Handle"
+				scale_factor="103" />
+		</Pieces>
+		<!-- Length: 192 Weight: 2.15 SwingSpeed: 52 ThrustSpeed: 96 SwingDamage: 25B, 0S ThrustDamage: 11B, 40S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_long_lance"
+		name="{=OGqTKRVm}Bamboo Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_bamboo_lance_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_aserai_bamboo_lance_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 225 Weight: 2.62 SwingSpeed: 38 ThrustSpeed: 91 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_heavy_lance"
+		name="{=lxDZyKbU}Aserai Heavy Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_heavy_lance_blade"
+				Type="Blade"
+				scale_factor="91" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_aserai_heavy_lance_handle"
+				Type="Handle"
+				scale_factor="97" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 21600 Weight: 2.46 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_lance"
+		name="{=J4fgemze}Sturgian Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_lance_blade"
+				Type="Blade"
+				scale_factor="100"></Piece>
+			<Piece
+				id="mp_sturgia_lance_handle"
+				Type="Handle"
+				scale_factor="107"></Piece>
+		</Pieces>
+		<!-- Length: 191 Weight: 1.41 SwingSpeed: 64 ThrustSpeed: 103 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_long_lance"
+		name="{=9aVMFixc}Sturgian Long Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_long_lance_blade"
+				Type="Blade"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_sturgia_lance_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 191 Weight: 1.41 SwingSpeed: 64 ThrustSpeed: 103 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_heavy_lance"
+		name="{=6eO6QDoE}Sturgian Heavy Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_heavy_lance_blade"
+				Type="Blade"
+				scale_factor="102"></Piece>
+			<Piece
+				id="mp_sturgia_lance_handle"
+				Type="Handle"
+				scale_factor="98"></Piece>
+		</Pieces>
+		<!-- Length: 191 Weight: 1.41 SwingSpeed: 64 ThrustSpeed: 103 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_spear"
+		name="{=DxRrAuRo}Battanian Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_spear_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_spear_guard_8"
+				Type="Guard" />
+			<Piece
+				id="mp_battania_spear_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 158 Weight: 1.54 SwingSpeed: 73 ThrustSpeed: 102 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_long_spear"
+		name="{=1A57qBlx}Battanian Long Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_long_spear_blade"
+				Type="Blade"></Piece>
+			<Piece
+				id="mp_spear_guard_2"
+				Type="Guard" />
+			<Piece
+				id="mp_battania_long_spear_handle"
+				Type="Handle"
+				scale_factor="106"></Piece>
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 179 Weight: 1.75 SwingSpeed: 60 ThrustSpeed: 99 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_long_infantry_spear"
+		name="{=wg8wXRLp}Battanian Long Infantry Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_long_infantry_spear_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_guard_12"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_battania_long_spear_handle"
+				Type="Handle"
+				scale_factor="98" />
+			<Piece
+				id="mp_spear_pommel_2"
+				Type="Pommel" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_cavalry_spear"
+		name="{=SUKemgo6}Battanian Cavalry Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_cavalry_spear_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_spear_guard_14"
+				Type="Guard"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_long_spear_handle"
+				Type="Handle"
+				scale_factor="109"></Piece>
+			<Piece
+				id="mp_spear_pommel_3"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 179 Weight: 1.75 SwingSpeed: 60 ThrustSpeed: 99 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_lance"
+		name="{=NSo8tGhT}Battanian Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_lance_blade"
+				Type="Blade"></Piece>
+			<Piece
+				id="mp_battania_lance_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 204 Weight: 1.77 SwingSpeed: 59 ThrustSpeed: 99 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_great_spear"
+		name="{=2PN7ddKx}Great Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_great_spear_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_spear_guard_14"
+				Type="Guard" />
+			<Piece
+				id="mp_sturgia_long_spear_handle"
+				Type="Handle"
+				scale_factor="106" />
+			<Piece
+				id="mp_spear_pommel_10"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 21600 Weight: 2.47 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_polearm"
+		name="{=1pjTjmHR}MP Test Polearm"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_test_polearm_head"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_test_polearm_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_spear"
+		name="{=bYmKOh4p}Test Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_spear_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_test_spear_handle"
+				Type="Handle"
+				scale_factor="108" />
+		</Pieces>
+		<!-- Length: 16300 Weight: 1.74 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_pike"
+		name="{=nPSYRs2Q}Test Pike"
+		crafting_template="Pike"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_pike_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_test_pike_handle"
+				Type="Handle"
+				scale_factor="105" />
+		</Pieces>
+		<!-- Length: 24700 Weight: 2.96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_lance"
+		name="{=ja2rER65}Test Lance"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_lance_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_test_lance_handle"
+				Type="Handle"
+				scale_factor="106" />
+		</Pieces>
+		<!-- Length: 18400 Weight: 2.08 -->
+	</CraftedItem>
+	<!-- #endregion -->
+	<!-- #region Sword -->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_short_sword"
+		name="{=3aPKkyd2}Vlandian Short Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_short_sword_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_vlandian_short_sword_guard"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_vlandian_short_sword_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_vlandian_short_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_pugio"
+		name="{=bVzkrtUc}Pugio"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_pugio_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_pugio_guard"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_pugio_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_pugio_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_gladius"
+		name="{=lwxOPEPx}Gladius"
+		crafting_template="OneHandedSword"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_empire_gladius_blade"
+				Type="Blade"
+				scale_factor="105" />
+			<Piece
+				id="mp_empire_gladius_guard"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_gladius_grip"
+				Type="Handle"
+				scale_factor="105" />
+			<Piece
+				id="mp_empire_gladius_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_northern_sword"
+		name="{=8dvj7xik}Sturgian Sword"
+		crafting_template="OneHandedSword"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_northern_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturgia_northern_sword_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_sturgia_northern_sword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturgia_northern_sword_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_sword"
+		name="{=Eb106Xg8}Sturgian Short Sword"
+		crafting_template="OneHandedSword"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_sword_blade"
+				Type="Blade"
+				scale_factor="108" />
+			<Piece
+				id="mp_sturgia_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_sturgia_sword_grip"
+				Type="Handle"
+				scale_factor="105" />
+			<Piece
+				id="mp_sturgia_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 8400 Weight: 1.37 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_cavalry_sword"
+		name="{=bOPllY2F}Sturgian Cavalry Sword"
+		crafting_template="OneHandedSword"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_cavalry_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturgia_cavalry_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_sturgia_cavalry_sword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturgia_cavalry_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 9100 Weight: 1.63 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandia_cavalry_sword"
+		name="{=hF11nBki}Vlandian Cavalry Sword"
+		crafting_template="OneHandedSword"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_western_cavalry_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_western_cavalry_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_western_cavalry_sword_grip"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_western_cavalry_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 9100 Weight: 1.63 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_arming_sword"
+		name="{=wwAFqJE3}Arming Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_arming_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_arming_sword_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_vlandian_arming_sword_grip"
+				Type="Handle" />
+			<Piece
+				id="mp_vlandian_arming_sword_pommel"
+				Type="Pommel"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 89 Weight: 1.35 SwingSpeed: 106 ThrustSpeed: 99 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_sabre"
+		name="{=UHcXARc6}Ild"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_strong_sabre_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_khuzait_light_sabre_guard"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_khuzait_sabre_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_khuzait_sabre_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 98 Weight: 1.32 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_heavy_sabre"
+		name="{=7zIWNagP}Heavy Ild"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_heavy_sabre_blade"
+				Type="Blade"
+				scale_factor="101" />
+			<Piece
+				id="mp_khuzait_heavy_sabre_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_heavy_sabre_grip"
+				Type="Handle" />
+			<Piece
+				id="mp_khuzait_heavy_sabre_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 89 Weight: 0.99 SwingSpeed: 107 ThrustSpeed: 100 SwingDamage: 13B, 55S ThrustDamage: 11B, 33S -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_cavalry_sabre"
+		name="{=jEHLd5gm}Kilij"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_cavalry_sabre_blade"
+				Type="Blade"
+				scale_factor="108" />
+			<Piece
+				id="mp_khuzait_cavalry_sabre_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_cavalry_sabre_grip"
+				Type="Handle" />
+			<Piece
+				id="mp_khuzait_cavalry_sabre_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 10200 Weight: 1.72 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_spatha"
+		name="{=M2wvaObX}Spatha"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_spatha_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_spatha_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_spatha_grip"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_empire_spatha_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 91 Weight: 1.18 SwingSpeed: 98 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_long_spatha"
+		name="{=vAQJvloo}Long Spatha"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_long_spatha_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_long_spatha_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_empire_long_spatha_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_long_spatha_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 8500 Weight: 1.53 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_paramerion"
+		name="{=5YGP047h}Paramerion"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_paramerion_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_empire_paramerion_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_empire_paramerion_grip"
+				Type="Handle" />
+			<Piece
+				id="mp_empire_paramerion_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 9400 Weight: 1.69 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_long_paramerion"
+		name="{=1tABvwsL}Long Paramerion"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_long_paramerion_blade"
+				Type="Blade"
+				scale_factor="107" />
+			<Piece
+				id="mp_empire_long_paramerion_guard"
+				Type="Guard"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_long_paramerion_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_empire_long_paramerion_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 9400 Weight: 1.69 -->
+	</CraftedItem>
+	<CraftedItem
+		id="mp_aserai_sword"
+		name="{=joroqAbR}Flyssa"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_sword_blade"
+				Type="Blade"
+				scale_factor="95" />
+			<Piece
+				id="mp_aserai_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_aserai_sword_grip"
+				Type="Handle" />
+			<Piece
+				id="mp_aserai_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 9100 Weight: 1.64 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_ranger_sword"
+		name="{=uF4IqQIK}Kaskara"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_ranger_sword_blade"
+				Type="Blade"
+				scale_factor="95" />
+			<Piece
+				id="mp_aserai_ranger_sword_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_ranger_sword_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_aserai_ranger_sword_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 97 Weight: 1.56 SwingSpeed: 91 ThrustSpeed: 96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_fast_sword"
+		name="{=KD4pxN2C}Aserai Noble Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_fast_sword_blade"
+				Type="Blade"
+				scale_factor="105" />
+			<Piece
+				id="mp_aserai_fast_sword_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_fast_sword_grip"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_fast_sword_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 97 Weight: 1.56 SwingSpeed: 91 ThrustSpeed: 96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandia_fast_sword"
+		name="{=UkR3F9lV}Vlandian Noble Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandia_fast_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandia_fast_sword_guard"
+				Type="Guard"
+				scale_factor="102" />
+			<Piece
+				id="mp_vlandia_fast_sword_grip"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_vlandia_fast_sword_pommel"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 97 Weight: 1.56 SwingSpeed: 91 ThrustSpeed: 96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_curved_long_sword"
+		name="{=QUGDr6Te}Scimitar"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_long_sword_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_long_sword_guard"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_aserai_long_sword_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_aserai_long_sword_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 116 Weight: 1.64 SwingSpeed: 81 ThrustSpeed: 95 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_noble_curved_long_sword"
+		name="{=1LHNLYqc}Heavy Scimitar"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_noble_long_sword_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_noble_long_sword_guard"
+				Type="Guard"
+				scale_factor="103" />
+			<Piece
+				id="mp_aserai_noble_long_sword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_aserai_noble_long_sword_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 11600 Weight: 2.13 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_long_sword"
+		name="{=FLBYsvxp}Long Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_long_sword_blade"
+				Type="Blade"
+				scale_factor="102" />
+			<Piece
+				id="mp_vlandian_long_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_vlandian_long_sword_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_vlandian_long_sword_pommel"
+				Type="Pommel"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 97 Weight: 1.75 SwingSpeed: 95 ThrustSpeed: 94 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_two_handed_sword"
+		name="{=FmN4ryxu}Great Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_2hsword_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_vlandian_2hsword_guard"
+				Type="Guard"
+				scale_factor="90" />
+			<Piece
+				id="mp_vlandian_2hsword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_2hsword_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 120 Weight: 1.95 SwingSpeed: 93 ThrustSpeed: 98 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_two_handed_sword"
+		name="{=Nk7bQUWJ}Aserai Two Handed Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_two_handed_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_aserai_two_handed_sword_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_two_handed_sword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_pommel_2"
+				Type="Pommel"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 11000 Weight: 1.87 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_noble_two_handed_sword"
+		name="{=5DVBFbLV}Noble Great Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_noble_two_handed_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_noble_two_handed_sword_guard"
+				Type="Guard"
+				scale_factor="100" />
+			<Piece
+				id="mp_vlandian_noble_two_handed_sword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_noble_two_handed_sword_pommel"
+				Type="Pommel"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 11000 Weight: 1.87 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_western_bastard_sword"
+		name="{=oeE1E3FJ}Vlandian Bastard Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_bastard_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_bastard_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_vlandian_bastard_sword_handle"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_vlandian_bastard_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 8400 Weight: 1.66 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_noble_bastard_sword"
+		name="{=l2j9CAQn}Bastard Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_noble_bastard_sword_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_noble_bastard_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_vlandian_noble_bastard_sword_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_noble_bastard_sword_pommel"
+				Type="Pommel"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 10300 Weight: 1.86 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_short_sword"
+		name="{=3c3uqW3d}Battanian Short Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_short_sword_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_short_sword_guard"
+				Type="Guard"
+				scale_factor="100"></Piece>
+			<Piece
+				id="mp_battania_short_sword_grip"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_short_sword_pommel"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 66 Weight: 1.33 SwingSpeed: 101 ThrustSpeed: 100 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_cavalry_sword"
+		name="{=arabgbEK}Battanian Cavalry Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_sword_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_sword_guard"
+				Type="Guard"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_sword_grip"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_sword_pommel"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 91 Weight: 1.64 SwingSpeed: 88 ThrustSpeed: 95 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_long_sword"
+		name="{=VTMc9pMS}Battanian Longsword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_long_sword_blade"
+				Type="Blade"
+				scale_factor="92"></Piece>
+			<Piece
+				id="mp_battania_long_sword_guard"
+				Type="Guard"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_long_sword_grip"
+				Type="Handle"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_long_sword_pommel"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_noble_sword"
+		name="{=RVkS0Mt3}Battanian Noble Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_noble_sword_blade"
+				Type="Blade"
+				scale_factor="100"></Piece>
+			<Piece
+				id="mp_battania_long_sword_guard"
+				Type="Guard"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_long_sword_grip"
+				Type="Handle"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_long_sword_pommel"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 116 Weight: 1.91 SwingSpeed: 74 ThrustSpeed: 92 -->
+	</CraftedItem>
+	<CraftedItem
+		id="mp_battania_cleaver"
+		name="{=mfeM775z}Cleaver"
+		crafting_template="OneHandedSword">
+		<Pieces>
+			<Piece
+				id="mp_battania_cleaver_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_battania_short_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_battania_bastard_sword_grip"
+				Type="Handle" />
+			<Piece
+				id="mp_battania_bastard_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_bastard_sword"
+		name="{=CuZ2eWxn}Battanian Bastard Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_bastard_sword_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_battania_bastard_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_battania_bastard_sword_grip"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_battania_bastard_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 11400 Weight: 2 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_falx"
+		name="{=QLcP8bIs}Falx"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_falx_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_falx_guard"
+				Type="Guard"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_falx_grip"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_falx_pommel"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 90 Weight: 1.54 SwingSpeed: 100 ThrustSpeed: 102 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_long_falx"
+		name="{=J4YgK18g}Long Falx"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_long_falx_blade"
+				Type="Blade"
+				scale_factor="105"></Piece>
+			<Piece
+				id="mp_battania_long_falx_guard"
+				Type="Guard"
+				scale_factor="90"></Piece>
+			<Piece
+				id="mp_battania_long_falx_grip"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_long_falx_pommel"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_polearm_falx"
+		name="{=8nObGQqW}Rhomphaia"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_polearm_falx_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_battania_polearm_falx_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_battania_polearm_falx_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_battania_polearm_falx_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 12300 Weight: 2.61 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_default_dagger"
+		name="{=mbT1uNPa}Dagger"
+		crafting_template="Dagger"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_dagger_blade_1"
+				Type="Blade"></Piece>
+			<Piece
+				id="mp_battania_dagger_guard"
+				Type="Guard"></Piece>
+			<Piece
+				id="mp_battania_dagger_grip"
+				Type="Handle"></Piece>
+			<Piece
+				id="mp_battania_dagger_pommel"
+				Type="Pommel"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_two_handed_sword"
+		name="{=1iS91QJH}Battanian Two Handed Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_2h_sword_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_2h_sword_guard"
+				Type="Guard"></Piece>
+			<Piece
+				id="mp_battania_2h_sword_grip"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_2h_sword_pommel"
+				Type="Pommel"></Piece>
+		</Pieces>
+		<!-- Length: 102 Weight: 1.51 SwingSpeed: 98 ThrustSpeed: 102 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_noble_two_handed_sword"
+		name="{=Is7j0Ir8}Battanian Noble Two Handed Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_2h_long_sword_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_2h_long_sword_guard"
+				Type="Guard"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_2h_long_sword_grip"
+				Type="Handle"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_battania_2h_long_sword_pommel"
+				Type="Pommel"
+				scale_factor="100"></Piece>
+		</Pieces>
+		<!-- Length: 96 Weight: 1.62 SwingSpeed: 100 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_sword"
+		name="{=u2QRZy2x}Mp Testing Sword"
+		crafting_template="OneHandedSword"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_sword_blade"
+				Type="Blade"
+				scale_factor="103" />
+			<Piece
+				id="mp_test_sword_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_test_sword_grip"
+				Type="Handle"
+				scale_factor="103" />
+			<Piece
+				id="mp_test_sword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 9200 Weight: 1.76 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_twohandedsword"
+		name="{=nhoDWrVf}MP Test 2h Sword"
+		crafting_template="TwoHandedSword"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_2hsword_blade"
+				Type="Blade"
+				scale_factor="107" />
+			<Piece
+				id="mp_test_2hsword_guard"
+				Type="Guard"
+				scale_factor="106" />
+			<Piece
+				id="mp_aserai_two_handed_sword_grip"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_test_2hsword_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 12000 Weight: 1.83 -->
+	</CraftedItem>
+	<!-- #endregion -->
+	<!-- #region Mace -->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_mace"
+		name="{=XcWJyWlF}Vlandian Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_mace_head"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_vlandia_mace_handle"
+				Type="Handle"
+				scale_factor="104" />
+		</Pieces>
+		<!-- Length: 76 Weight: 2.06 SwingSpeed: 74 ThrustSpeed: 90 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_cavalry_mace"
+		name="{=Hy4uQ7d5}Vlandian Cavalry Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_cavalry_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandia_cavalry_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 7400 Weight: 1.86 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_cavalry_mace"
+		name="{=Gbfot0SN}Aserai Cavalry Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_cavalry_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_aserai_cavalry_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 7400 Weight: 1.86 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_military_pick"
+		name="{=pTtFr5Iw}Vlandian Military Sickle"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_military_pick_head"
+				Type="Blade" />
+			<Piece
+				id="mp_vlandia_military_pick_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 9000 Weight: 1.2 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_mace"
+		name="{=Np2OoVNd}Sturgian Light Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandia_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 7300 Weight: 1.24 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_mace"
+		name="{=vh1x8VWw}Imperial Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 6000 Weight: 2.04 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_cavalry_mace"
+		name="{=y3RNBGtv}Imperial Cavalry Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_cavalry_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_cavalry_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 6000 Weight: 2.04 -->
+	</CraftedItem>
+	<!--Todo-->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_heavy_mace"
+		name="{=4xUR2kAj}Imperial Heavy Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_heavy_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_heavy_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 74 Weight: 1.32 SwingSpeed: 90 ThrustSpeed: 100 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battnia_heavy_mace"
+		name="{=1yvsiaZ6}Battanian Heavy Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_empire_heavy_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_empire_heavy_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 74 Weight: 1.32 SwingSpeed: 90 ThrustSpeed: 100 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_mace"
+		name="{=bkg0kWHH}Khuzait Infantry Club"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_mace_head"
+				Type="Blade" />
+			<Piece
+				id="mp_test_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 6300 Weight: 2.19 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_heavy_mace"
+		name="{=AHel76R6}Khuzait Heavy Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_heavy_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_khuzait_heavy_mace_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 7600 Weight: 1.86 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_cavalry_mace"
+		name="{=jy1VQ7Yg}Khuzait Cavalry Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_cavalry_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_khuzait_cavalry_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 69 Weight: 3.11 SwingSpeed: 63 ThrustSpeed: 80 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_mace"
+		name="{=ujB7Eq9S}Aserai Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_aserai_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 58 Weight: 0.47 SwingSpeed: 116 ThrustSpeed: 116 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_heavy_mace"
+		name="{=bZ0aUz2b}Aserai Heavy Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_heavy_mace_head"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_aserai_heavy_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 58 Weight: 0.47 SwingSpeed: 116 ThrustSpeed: 116 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_hammer"
+		name="{=t68bkisr}Hammer"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_hammer_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_hammer_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 52 Weight: 1.21 SwingSpeed: 98 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_twohanded_hammer"
+		name="{=Ae9L1a9g}Maul"
+		crafting_template="TwoHandedMace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_2hhammer_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturgia_2hammer_handle"
+				Type="Handle"
+				scale_factor="100" />
+		</Pieces>
+		<!-- Length: 10500 Weight: 1.34 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_twohanded_mace"
+		name="{=bdgTtBDq}Twohanded Iron Mace"
+		crafting_template="TwoHandedMace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_maul_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_sturgia_2hammer_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 10500 Weight: 1.34 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_twohanded_hammer"
+		name="{=aT7w4Npp}Battanian Spiked Mace"
+		crafting_template="TwoHandedMace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_2hhammer_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_battania_2hammer_handle"
+				Type="Handle"
+				scale_factor="92" />
+		</Pieces>
+		<!-- Length: 10500 Weight: 1.34 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_mace"
+		name="{=bcnknjPD}Battanian Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_mace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_battania_mace_handle"
+				Type="Handle"
+				scale_factor="107" />
+		</Pieces>
+		<!-- Length: 6000 Weight: 1.58 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_mace"
+		name="{=9NW9y1ll}Mp Test Mace"
+		crafting_template="Mace"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_test_mace_head"
+				Type="Blade"
+				scale_factor="105" />
+			<Piece
+				id="mp_test_mace_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 6600 Weight: 1.65 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_test_twohandedmace"
+		name="{=nmLZEjYg}MP Test 2h Mace"
+		crafting_template="TwoHandedMace"
+		value="1"
+		is_merchandise="false">
+		<Pieces>
+			<Piece
+				id="mp_test_2hmace_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_test_2hmace_handle"
+				Type="Handle" />
+		</Pieces>
+		<!-- Length: 10500 Weight: 1.34 -->
+	</CraftedItem>
+	<!-- #endregion -->
+	<!-- #region Bow -->
+	<Item
+		multiplayer_item="true"
+		id="mp_crossbow"
+		name="{=TTWL7RLe}Crossbow"
+		body_name="bo_composite_crossbows"
+		mesh="crossbow_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		difficulty="0"
+		Type="Crossbow"
+		AmmoOffset="0.0, 0.02131, 0.22975"
+		item_holsters="crossbow_back:bow_hip:mace_right_hip:bow_hip_2"
+		holster_position_shift="0.02,0,-0.4">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Crossbow"
+				ammo_class="Bolt"
+				missile_speed="100"
+				accuracy="98"
+				thrust_damage="76"
+				thrust_speed="78"
+				speed_rating="60"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="crossbow"
+				reload_phase_count="2"
+				physics_material="wood_weapon"
+				center_of_mass="0,0,0.4">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					CantReloadOnHorseback="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true" />
+			</Weapon>
+		</ItemComponent>
+		<!--flag name="AmmoOffset" value="0.0, 0.02131, -0.15" /-->
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_crossbow_faster_reload"
+		name="{=CPI0wkaZ}Hickory Crossbow"
+		body_name="bo_composite_crossbows"
+		mesh="crossbow_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		difficulty="0"
+		Type="Crossbow"
+		AmmoOffset="0.0, 0.02131, 0.22975"
+		item_holsters="crossbow_back:bow_hip:mace_right_hip:bow_hip_2"
+		holster_position_shift="0.02,0,-0.4">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Crossbow"
+				ammo_class="Bolt"
+				missile_speed="82"
+				accuracy="97"
+				thrust_damage="76"
+				thrust_speed="100"
+				speed_rating="63"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="crossbow"
+				reload_phase_count="2"
+				physics_material="wood_weapon"
+				center_of_mass="0,0,0.4">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					CantReloadOnHorseback="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true" />
+			</Weapon>
+		</ItemComponent>
+		<!--flag name="AmmoOffset" value="0.0, 0.02131, -0.15" /-->
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_light_crossbow"
+		name="{=K1UFTirG}Light Crossbow"
+		body_name="bo_cross_bow_heavy"
+		mesh="crossbow_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		Type="Crossbow"
+		AmmoOffset="0.0, 0.02131, 0.24650"
+		item_holsters="crossbow_back:bow_hip:mace_right_hip:bow_hip_2"
+		holster_position_shift="0.02,0,-0.4">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Crossbow"
+				ammo_class="Bolt"
+				missile_speed="77"
+				accuracy="95"
+				thrust_damage="67"
+				thrust_speed="110"
+				speed_rating="77"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="crossbow_fast"
+				reload_phase_count="2"
+				physics_material="wood_weapon"
+				center_of_mass="0,0,0.4">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					CantReloadOnHorseback="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true" />
+			</Weapon>
+		</ItemComponent>
+		<!--flag name="AmmoOffset" value="0.0, 0.02131, -0.15" /-->
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavier_crossbow_faster_draw"
+		name="{=r07M9xbT}Heavy Crossbow"
+		body_name="bo_cross_bow_heavy"
+		mesh="crossbow_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		difficulty="0"
+		Type="Crossbow"
+		AmmoOffset="0.0, 0.02131, 0.24975"
+		item_holsters="crossbow_back:bow_hip:mace_right_hip:bow_hip_2"
+		holster_position_shift="0.02,0,-0.4">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Crossbow"
+				ammo_class="Bolt"
+				missile_speed="110"
+				accuracy="99"
+				thrust_damage="84"
+				thrust_speed="80"
+				speed_rating="61"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="crossbow"
+				reload_phase_count="2"
+				physics_material="wood_weapon"
+				center_of_mass="0,0,0.4">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					CantReloadOnHorseback="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavier_crossbow"
+		name="{=0e17RZrZ}Arbalest"
+		body_name="bo_cross_bow_heavy"
+		mesh="crossbow_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.0"
+		difficulty="0"
+		Type="Crossbow"
+		AmmoOffset="0.0, 0.02131, 0.24675"
+		item_holsters="crossbow_back:bow_hip:mace_right_hip:bow_hip_2"
+		holster_position_shift="0.02,0,-0.4">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Crossbow"
+				ammo_class="Bolt"
+				missile_speed="110"
+				accuracy="100"
+				thrust_damage="84"
+				thrust_speed="50"
+				speed_rating="57"
+				weapon_length="100"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="crossbow"
+				reload_phase_count="2"
+				physics_material="wood_weapon"
+				center_of_mass="0,0,0.4">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					CantReloadOnHorseback="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_steppe_short_bow"
+		name="{=RJ8CcdJn}Steppe Short Bow"
+		body_name="bo_composite_shotbow_g"
+		mesh="shortbow_g"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.1"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="70"
+				accuracy="94"
+				thrust_damage="52"
+				thrust_speed="100"
+				speed_rating="86"
+				weapon_length="93"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_steppe_fast_short_bow"
+		name="{=aKIqpIf0}Steppe Fast Short Bow"
+		body_name="bo_composite_shotbow_f"
+		mesh="shortbow_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="64"
+				accuracy="90"
+				thrust_damage="50"
+				thrust_speed="125"
+				speed_rating="96"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_steppe_superior_bow"
+		name="{=0h7l0uK3}Steppe Superior Bow"
+		body_name="bo_composite_longbow_a"
+		mesh="bow_roman_a"
+		weight="1.4"
+		value="1"
+		is_merchandise="false"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="65"
+				accuracy="98"
+				thrust_damage="48"
+				thrust_speed="100"
+				speed_rating="90"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_hunting_bow"
+		name="{=wltdyF2j}Hunting Bow"
+		body_name="bo_composite_shotbow_h"
+		mesh="shortbow_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="64"
+				accuracy="80"
+				thrust_damage="40"
+				thrust_speed="110"
+				speed_rating="91"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_hunting_bow_faster_arrows"
+		name="{=wltdyF2j}Hunting Bow"
+		body_name="bo_composite_shotbow_h"
+		mesh="shortbow_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="85"
+				accuracy="89"
+				thrust_damage="42"
+				thrust_speed="110"
+				speed_rating="91"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_fast_hunting_bow"
+		name="{=9GCPcCss}Fast Hunting Bow"
+		body_name="bo_composite_shotbow_h"
+		mesh="shortbow_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="64"
+				accuracy="70"
+				thrust_damage="30"
+				thrust_speed="130"
+				speed_rating="91"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_nomad_bow"
+		name="{=rq5FMLVI}Nomad Short Bow"
+		body_name="bo_composite_shotbow_c"
+		mesh="shortbow_c"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		difficulty="30"
+		appearance="0.5"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				ammo_limit="1"
+				thrust_speed="100"
+				speed_rating="89"
+				missile_speed="75"
+				weapon_length="110"
+				accuracy="95"
+				thrust_damage="45"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_short_bow"
+		name="{=xb2tMFSz}Short Bow"
+		body_name="bo_composite_shotbow_g"
+		mesh="shortbow_g"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="70"
+				accuracy="90"
+				thrust_damage="48"
+				thrust_speed="100"
+				speed_rating="89"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_hunting_long_bow"
+		name="{=7rhZlXdO}Hunting Longbow"
+		body_name="bo_composite_longbow_e"
+		mesh="longbow_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.0"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="68"
+				accuracy="94"
+				thrust_damage="55"
+				thrust_speed="75"
+				speed_rating="86"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="long_bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.15,0,0">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_recurve_bow"
+		name="{=IJjrSbiV}Recurve Bow"
+		body_name="bo_composite_shotbow_c"
+		mesh="shortbow_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="73"
+				accuracy="95"
+				thrust_damage="50"
+				thrust_speed="90"
+				speed_rating="88"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_guards_bow"
+		name="{=iauvbwL3}Guard's Bow"
+		body_name="bo_composite_shotbow_c"
+		mesh="shortbow_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="73"
+				accuracy="95"
+				thrust_damage="63"
+				thrust_speed="80"
+				speed_rating="88"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_superior_bow"
+		name="{=3eb3ZyiU}Superior Bow"
+		body_name="bo_composite_longbow_a"
+		mesh="bow_roman_a"
+		weight="1.5"
+		value="1"
+		is_merchandise="false"
+		difficulty="0"
+		appearance="0.5"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="65"
+				accuracy="98"
+				thrust_damage="45"
+				thrust_speed="100"
+				speed_rating="89"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_mountain_hunting_bow"
+		name="{=YGQ6UXCo}Mountain Hunting Bow"
+		body_name="bo_composite_shotbow_h"
+		mesh="shortbow_i"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		difficulty="0"
+		appearance="1"
+		Type="Bow"
+		item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="65"
+				accuracy="83"
+				thrust_damage="40"
+				thrust_speed="120"
+				speed_rating="92"
+				weapon_length="108"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_nordic_short_bow"
+		name="{=tEimkEsU}Nordic Shortbow"
+		body_name="bo_composite_shotbow_c"
+		mesh="shortbow_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		difficulty="0"
+		appearance="0.6"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="60"
+				accuracy="80"
+				thrust_damage="45"
+				thrust_speed="125"
+				speed_rating="93"
+				weapon_length="108"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_fast_short_bow"
+		name="{=WsUvpBwM}Fast Short Bow"
+		body_name="bo_composite_shotbow_f"
+		mesh="shortbow_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="61"
+				accuracy="88"
+				thrust_damage="48"
+				thrust_speed="125"
+				speed_rating="93"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_strong_recurve_bow"
+		name="{=xODbCO6k}Composite Bow"
+		body_name="bo_composite_shotbow_a"
+		mesh="shortbow_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.8"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="70"
+				accuracy="96"
+				thrust_damage="59"
+				thrust_speed="95"
+				speed_rating="89"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.0,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_long_bow"
+		name="{=KTegaNPW}Longbow"
+		body_name="bo_composite_longbow_a"
+		mesh="longbow_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.0"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="80"
+				accuracy="96"
+				thrust_damage="58"
+				thrust_speed="65"
+				speed_rating="85"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="long_bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.15,0,0">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_imperial_recurve_bow"
+		name="{=OuD7PfvY}Imperial Recurve Bow"
+		body_name="bo_composite_shotbow_b"
+		mesh="shortbow_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		difficulty="0"
+		appearance="0.4"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="60"
+				accuracy="98"
+				thrust_damage="51"
+				thrust_speed="90"
+				speed_rating="88"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.0,0,-0.1"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_lowland_long_bow"
+		name="{=A6llHL9s}Lowland Longbow"
+		body_name="bo_composite_longbow_a"
+		mesh="longbow_a"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		subtype="bow"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.4"
+		Type="Bow"
+		item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="80"
+				accuracy="95"
+				thrust_damage="55"
+				thrust_speed="60"
+				speed_rating="83"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="long_bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.15,0,0"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_woodland_long_bow"
+		name="{=ZFwKlHIJ}Woodland Longbow"
+		body_name="bo_composite_longbow_a"
+		mesh="longbow_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.3"
+		Type="Bow"
+		item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="75"
+				accuracy="97"
+				thrust_damage="67"
+				thrust_speed="75"
+				speed_rating="86"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="long_bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.15,0,0"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_tribesman_long_bow"
+		name="{=XiI81DUa}Tribesman Longbow"
+		body_name="bo_composite_longbow_g"
+		mesh="longbow_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		appearance="0.6"
+		Type="Bow"
+		item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="90"
+				accuracy="97"
+				thrust_damage="65"
+				thrust_speed="75"
+				speed_rating="86"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="long_bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.15,0,0"
+				modifier_group="bow">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_yeow_long_bow"
+		name="{=3XSuOAYT}Yeow Longbow"
+		body_name="bo_composite_longbow_g"
+		mesh="longbow_j"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="90"
+				accuracy="98"
+				thrust_damage="67"
+				thrust_speed="60"
+				speed_rating="84"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="long_bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.15,0,0">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_hunting_bow_captain"
+		name="{=wltdyF2j}Hunting Bow"
+		body_name="bo_composite_shotbow_h"
+		mesh="shortbow_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="64"
+				accuracy="90"
+				thrust_damage="38"
+				thrust_speed="110"
+				speed_rating="91"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_recurve_bow_captain"
+		name="{=IJjrSbiV}Recurve Bow"
+		body_name="bo_composite_shotbow_c"
+		mesh="shortbow_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="1.6"
+		difficulty="0"
+		Type="Bow"
+		item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bow"
+				ammo_class="Arrow"
+				missile_speed="73"
+				accuracy="96"
+				thrust_damage="50"
+				thrust_speed="89"
+				speed_rating="88"
+				weapon_length="95"
+				ammo_limit="1"
+				thrust_damage_type="Pierce"
+				item_usage="bow"
+				physics_material="wood_weapon"
+				center_of_mass="0.1,0,-0.15">
+				<WeaponFlags
+					RangedWeapon="true"
+					HasString="true"
+					StringHeldByHand="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Throwing -->
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_throwing_spear"
+		name="{=uwkGsgxJ}Khuzait Throwing Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_throwing_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_15"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_throwing_spear_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 16700 Weight: 1.96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_khuzait_extra_throwing_spear"
+		name="{=uwkGsgxJ}Khuzait Throwing Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_khuzait_extra_throwing_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_15"
+				Type="Guard" />
+			<Piece
+				id="mp_khuzait_throwing_spear_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 16700 Weight: 1.96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_ash_throwing_spear"
+		name="{=VIVfoHRj}Ash Throwing Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_ash_throwing_spear_blade"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_4"
+				Type="Guard" />
+			<Piece
+				id="mp_ash_throwing_spear_handle"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 16700 Weight: 1.96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_ash_throwing_spear_extra"
+		name="{=VIVfoHRj}Ash Throwing Spear"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_ash_throwing_spear_blade_extra"
+				Type="Blade"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_guard_4"
+				Type="Guard" />
+			<Piece
+				id="mp_ash_throwing_spear_handle"
+				Type="Handle"
+				scale_factor="100" />
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 16700 Weight: 1.96 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battanian_throwing_axe"
+		name="{=MS1gaKXk}Battanian Throwing Axe"
+		crafting_template="ThrowingAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.battania">
+		<Pieces>
+			<Piece
+				id="mp_battanian_throwing_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_battanian_throwing_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 34 Weight: 0.75 SwingSpeed: 135 ThrustSpeed: 109 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_throwing_axe"
+		name="{=F4xD8gjJ}Francesca"
+		crafting_template="ThrowingAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_throwing_axe_head"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_vlandian_throwing_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 34 Weight: 0.75 SwingSpeed: 135 ThrustSpeed: 109 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_vlandian_throwing_axe_extra"
+		name="{=F4xD8gjJ}Francesca"
+		crafting_template="ThrowingAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_vlandian_throwing_axe_head_extra"
+				Type="Blade" />
+			<Piece
+				id="mp_vlandian_throwing_axe_handle"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 34 Weight: 0.75 SwingSpeed: 135 ThrustSpeed: 109 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_throwing_axe"
+		name="{=2FwUtU6h}Sturgian Throwing Axe"
+		crafting_template="ThrowingAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_throwing_axe_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_throwing_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_throwing_axe_captain"
+		name="{=2FwUtU6h}Sturgian Throwing Axe"
+		crafting_template="ThrowingAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_throwing_axe_head_captain"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_throwing_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 34 Weight: 0.79 SwingSpeed: 112 ThrustSpeed: 108 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_aserai_throwing_axe"
+		name="{=LI3rc6S2}Aserai Throwing Axe"
+		crafting_template="ThrowingAxe"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_aserai_throwing_axe_head"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_aserai_throwing_axe_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 34 Weight: 0.79 SwingSpeed: 112 ThrustSpeed: 108 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_harpoon"
+		name="{=aDeVl2EL}Sturgian Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_harpoon_blade"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_harpoon_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 87 Weight: 0.97 SwingSpeed: 105 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_harpoon_extra"
+		name="{=aDeVl2EL}Sturgian Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_harpoon_blade_extra"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_harpoon_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 87 Weight: 0.97 SwingSpeed: 105 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_harpoon_strong"
+		name="{=Y7wtGUKA}Sturgian Heavy Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_harpoon_blade_strong"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_harpoon_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 87 Weight: 0.97 SwingSpeed: 105 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_harpoon_captain"
+		name="{=AWlrtbep}Northern Fish Harpoon"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_harpoon_blade_captain"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_harpoon_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 87 Weight: 0.97 SwingSpeed: 105 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_harpoon_extra_captain"
+		name="{=AWlrtbep}Northern Fish Harpoon"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_harpoon_blade_extra_captain"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_harpoon_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 87 Weight: 0.97 SwingSpeed: 105 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_sturgia_harpoon_strong_captain"
+		name="{=WOzcBg62}Reinforced Northern Fish Harpoon"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_sturgia_harpoon_blade_strong_captain"
+				Type="Blade"
+				scale_factor="110"></Piece>
+			<Piece
+				id="mp_sturgia_harpoon_handle"
+				Type="Handle"
+				scale_factor="110"></Piece>
+		</Pieces>
+		<!-- Length: 87 Weight: 0.97 SwingSpeed: 105 ThrustSpeed: 106 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_javelin"
+		name="{=cBZ6OlKW}Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_javelin_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_javelin_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 85 Weight: 1.25 SwingSpeed: 97 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_javelin_extraammo"
+		name="{=cBZ6OlKW}Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_javelin_blade_extraammo"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_javelin_handle_extraammo"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 85 Weight: 1.25 SwingSpeed: 97 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_javelin_captain"
+		name="{=PF7sPCYq}Javelins"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_javelin_blade_captain"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_javelin_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 85 Weight: 1.25 SwingSpeed: 97 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_javelin_extraammo_captain"
+		name="{=PF7sPCYq}Javelins"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_javelin_blade_extraammo_captain"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_javelin_handle_extraammo"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 85 Weight: 1.25 SwingSpeed: 97 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_javelin"
+		name="{=EPehLvzV}Imperial Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_javelin_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_spear_guard_15"
+				Type="Guard" />
+			<Piece
+				id="mp_jereed_handle"
+				Type="Handle" />
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 76 Weight: 1.1 SwingSpeed: 102 ThrustSpeed: 103 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_empire_javelin_captain"
+		name="{=FexNLsO5}Imperial Javelins"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_javelin_blade_captain"
+				Type="Blade" />
+			<Piece
+				id="mp_spear_guard_15"
+				Type="Guard" />
+			<Piece
+				id="mp_jereed_handle"
+				Type="Handle" />
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 76 Weight: 1.1 SwingSpeed: 102 ThrustSpeed: 103 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_light_javelin"
+		name="{=brmba4ca}Light Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_light_javelin_blade"
+				Type="Blade" />
+			<Piece
+				id="mp_light_javelin_handle"
+				Type="Handle"
+				scale_factor="90" />
+		</Pieces>
+		<!-- Length: 76 Weight: 1.1 SwingSpeed: 102 ThrustSpeed: 103 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_plumbata"
+		name="{=ajifXc8I}Plumbata"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_plumbata_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_guard"
+				Type="Guard" />
+			<Piece
+				id="mp_plumbata_handle"
+				Type="Handle"
+				scale_factor="110" />
+			<Piece
+				id="mp_default_polearm_pommel"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 4700 Weight: 0.65 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_pilum"
+		name="{=v3lIxLvX}Pila"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_pilum_blade"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_guard_7"
+				Type="Guard" />
+			<Piece
+				id="mp_pilum_handle"
+				Type="Handle"
+				scale_factor="105" />
+		</Pieces>
+		<!-- Length: 142 Weight: 1.83 SwingSpeed: 72 ThrustSpeed: 92 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_pilum_extraammo"
+		name="{=v3lIxLvX}Pila"
+		crafting_template="TwoHandedPolearm"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_pilum_blade_extraammo"
+				Type="Blade"
+				scale_factor="110" />
+			<Piece
+				id="mp_spear_guard_7"
+				Type="Guard" />
+			<Piece
+				id="mp_pilum_handle_extraammo"
+				Type="Handle"
+				scale_factor="110" />
+		</Pieces>
+		<!-- Length: 142 Weight: 1.83 SwingSpeed: 72 ThrustSpeed: 92 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_jereed"
+		name="{=Z6Ak3H6G}Jereed"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_jereed_blade"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_jereed_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_pommel_12"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 110 Weight: 1.25 SwingSpeed: 94 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_jereed_extra"
+		name="{=Z6Ak3H6G}Jereed"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_jereed_blade_extra"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_jereed_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_pommel_12"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 110 Weight: 1.25 SwingSpeed: 94 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_jereed_captain"
+		name="{=Z6Ak3H6G}Jereed"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_jereed_blade_captain"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_jereed_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_pommel_12"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 110 Weight: 1.25 SwingSpeed: 94 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_jereed_extra_captain"
+		name="{=Z6Ak3H6G}Jereed"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_jereed_blade_extra_captain"
+				Type="Blade"
+				scale_factor="90" />
+			<Piece
+				id="mp_jereed_handle"
+				Type="Handle"
+				scale_factor="90" />
+			<Piece
+				id="mp_spear_pommel_12"
+				Type="Pommel" />
+		</Pieces>
+		<!-- Length: 110 Weight: 1.25 SwingSpeed: 94 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_javelin"
+		name="{=YHWqNIYu}Battanian Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_javelin_blade"
+				Type="Blade"
+				scale_factor="105"></Piece>
+			<Piece
+				id="mp_battania_javelin_handle"
+				Type="Handle"
+				scale_factor="102"></Piece>
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 99 Weight: 1.26 SwingSpeed: 93 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_javelin_extra"
+		name="{=YHWqNIYu}Battanian Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_javelin_blade_extra"
+				Type="Blade"
+				scale_factor="105"></Piece>
+			<Piece
+				id="mp_battania_javelin_handle"
+				Type="Handle"
+				scale_factor="102"></Piece>
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 99 Weight: 1.26 SwingSpeed: 93 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_javelin_captain"
+		name="{=v1CIJWs1}Highland Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_javelin_blade_captain"
+				Type="Blade"
+				scale_factor="105"></Piece>
+			<Piece
+				id="mp_battania_javelin_handle"
+				Type="Handle"
+				scale_factor="102"></Piece>
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 99 Weight: 1.26 SwingSpeed: 93 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<CraftedItem
+		multiplayer_item="true"
+		id="mp_battania_javelin_extra_captain"
+		name="{=v1CIJWs1}Highland Javelin"
+		crafting_template="Javelin"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.neutral_culture">
+		<Pieces>
+			<Piece
+				id="mp_battania_javelin_blade_extra_captain"
+				Type="Blade"
+				scale_factor="105"></Piece>
+			<Piece
+				id="mp_battania_javelin_handle"
+				Type="Handle"
+				scale_factor="102"></Piece>
+			<Piece
+				id="mp_spear_pommel_8"
+				Type="Pommel"
+				scale_factor="90"></Piece>
+		</Pieces>
+		<!-- Length: 99 Weight: 1.26 SwingSpeed: 93 ThrustSpeed: 101 -->
+	</CraftedItem>
+	<!-- #endregion -->
+	<!-- #region Missile -->
+	<Item
+		id="mp_bolts_western"
+		name="{=JbTCDDb0}Bolt"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="bolt_bl_c"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="bolt_bl_c_quiver"
+		holster_mesh_with_weapon="bolt_bl_c_quiver"
+		flying_mesh="bolt_bl_flying"
+		weight="0.05"
+		appearance="1"
+		Type="Bolts"
+		item_holsters="quiver_bolts:quiver_bolts_2:quiver_back_middle:quiver_back_top">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bolt"
+				stack_amount="25"
+				thrust_speed="0"
+				thrust_damage_type="Pierce"
+				thrust_damage="0"
+				speed_rating="0"
+				missile_speed="10"
+				weapon_length="37"
+				item_usage=""
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="180, 0, 0"
+				physics_material="missile"
+				sticking_position="0,-0.37,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.1"
+				modifier_group="bolt">
+				<WeaponFlags
+					AttachAmmoToVisual="true"
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_bolts_western_extra"
+		name="{=JbTCDDb0}Bolt"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="bolt_bl_c"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="bolt_bl_c_quiver"
+		holster_mesh_with_weapon="bolt_bl_c_quiver"
+		flying_mesh="bolt_bl_flying"
+		weight="0.05"
+		appearance="1"
+		Type="Bolts"
+		item_holsters="quiver_bolts:quiver_bolts_2:quiver_back_middle:quiver_back_top">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bolt"
+				stack_amount="35"
+				thrust_speed="0"
+				thrust_damage_type="Pierce"
+				thrust_damage="0"
+				speed_rating="0"
+				missile_speed="10"
+				weapon_length="37"
+				item_usage=""
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="180, 0, 0"
+				physics_material="missile"
+				sticking_position="0,-0.37,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.1"
+				modifier_group="bolt">
+				<WeaponFlags
+					AttachAmmoToVisual="true"
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_bolts_western_extra_captain"
+		name="{=JbTCDDb0}Bolt"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="bolt_bl_c"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="bolt_bl_c_quiver"
+		holster_mesh_with_weapon="bolt_bl_c_quiver"
+		flying_mesh="bolt_bl_flying"
+		weight="0.05"
+		appearance="1"
+		Type="Bolts"
+		item_holsters="quiver_bolts:quiver_bolts_2:quiver_back_middle:quiver_back_top">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bolt"
+				stack_amount="45"
+				thrust_speed="0"
+				thrust_damage_type="Pierce"
+				thrust_damage="0"
+				speed_rating="0"
+				missile_speed="10"
+				weapon_length="37"
+				item_usage=""
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="180, 0, 0"
+				physics_material="missile"
+				sticking_position="0,-0.37,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.1"
+				modifier_group="bolt">
+				<WeaponFlags
+					AttachAmmoToVisual="true"
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_bolts_strong"
+		name="{=07OrsbVH}Strong Bolt"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="bolt_bl_a"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="bolt_bl_a_quiver"
+		flying_mesh="bolt_bl_flying"
+		holster_mesh_with_weapon="bolt_bl_a_quiver"
+		weight="0.06"
+		appearance="1"
+		Type="Bolts"
+		item_holsters="quiver_bolts:quiver_bolts_2:quiver_back_middle:quiver_back_top">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bolt"
+				stack_amount="25"
+				thrust_speed="0"
+				thrust_damage_type="Pierce"
+				thrust_damage="4"
+				speed_rating="0"
+				missile_speed="10"
+				weapon_length="47"
+				item_usage=""
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="180, 0, 0"
+				physics_material="missile"
+				sticking_position="0,-0.47,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.1"
+				modifier_group="bolt">
+				<WeaponFlags
+					AttachAmmoToVisual="true"
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_bolts_imperial"
+		name="{=yQqsd0bh}Imperial Bolt"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="bolt_bl_e"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="bolt_bl_e_quiver"
+		holster_mesh_with_weapon="bolt_bl_e_quiver"
+		flying_mesh="bolt_bl_flying"
+		weight="0.05"
+		appearance="1"
+		Type="Bolts"
+		item_holsters="quiver_bolts:quiver_bolts_2:quiver_back_middle:quiver_back_top">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Bolt"
+				stack_amount="25"
+				thrust_speed="0"
+				thrust_damage_type="Pierce"
+				thrust_damage="0"
+				speed_rating="0"
+				missile_speed="10"
+				weapon_length="37"
+				item_usage=""
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="180, 0, 0"
+				physics_material="missile"
+				sticking_position="0,-0.37,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.1"
+				modifier_group="bolt">
+				<WeaponFlags
+					AttachAmmoToVisual="true"
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			ForceAttachOffHandPrimaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_arrows_steppe"
+		name="{=OdsXaOjG}Khuzait Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_f"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.khuzait"
+		weight="0.05"
+		appearance="0.5"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_f_quiver"
+		holster_mesh_with_weapon="arrow_bl_f_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_lower:quiver_back_lower_2"
+		holster_position_shift="0.0,0.0,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="35"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.15,-0.1">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_steppe_extra"
+		name="{=OdsXaOjG}Khuzait Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_f"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.khuzait"
+		weight="0.05"
+		appearance="0.5"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_f_quiver"
+		holster_mesh_with_weapon="arrow_bl_f_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_lower:quiver_back_lower_2"
+		holster_position_shift="0.0,0.0,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="50"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.05,-0.0">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_steppe_strong"
+		name="{=I2yl5DWj}Heavy Khuzait Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_e"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.khuzait"
+		weight="0.06"
+		appearance="1"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_e_quiver"
+		holster_mesh_with_weapon="arrow_bl_e_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_lower:quiver_back_lower_2"
+		holster_position_shift="0.0,0.0,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="35"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="4"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="-0.00,0.05,-0.00"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		id="mp_arrows_steppe_mounted"
+		name="{=OdsXaOjG}Khuzait Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_f"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.khuzait"
+		weight="0.05"
+		appearance="0.5"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_f_quiver"
+		holster_mesh_with_weapon="arrow_bl_f_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_lower:quiver_back_lower_2"
+		holster_position_shift="0.0,0.0,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="32"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.15,-0.1">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_steppe_extra_mounted"
+		name="{=OdsXaOjG}Khuzait Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_f"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.khuzait"
+		weight="0.05"
+		appearance="0.5"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_f_quiver"
+		holster_mesh_with_weapon="arrow_bl_f_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_lower:quiver_back_lower_2"
+		holster_position_shift="0.0,0.0,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="47"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.05,-0.0">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_steppe_strong_mounted"
+		name="{=I2yl5DWj}Heavy Khuzait Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_e"
+		value="1"
+		is_merchandise="false"
+		culture="Culture.khuzait"
+		weight="0.06"
+		appearance="1"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_e_quiver"
+		holster_mesh_with_weapon="arrow_bl_e_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_lower:quiver_back_lower_2"
+		holster_position_shift="0.0,0.0,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="32"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="4"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="-0.00,0.05,-0.00"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		id="mp_arrows_bodkin"
+		name="{=mXQsNAmZ}Bodkin Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_g"
+		value="1"
+		is_merchandise="false"
+		weight="0.05"
+		appearance="1"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_h_quiver"
+		holster_mesh_with_weapon="arrow_bl_h_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts"
+		holster_position_shift="0.0,0.0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="35"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.13"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		id="mp_arrows_bodkin_extra"
+		name="{=mXQsNAmZ}Bodkin Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_g"
+		value="1"
+		is_merchandise="false"
+		weight="0.05"
+		appearance="1"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_h_quiver"
+		holster_mesh_with_weapon="arrow_bl_h_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts"
+		holster_position_shift="0.0,0.0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="50"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.13"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_bodkin_strong"
+		name="{=jm9CnURw}Heavy Bodkin Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_i"
+		value="1"
+		is_merchandise="false"
+		weight="0.06"
+		appearance="1"
+		flying_mesh="arrow_bl_flying"
+		holster_mesh="arrow_bl_i_quiver"
+		holster_mesh_with_weapon="arrow_bl_i_quiver"
+		Type="Arrows"
+		item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts"
+		holster_position_shift="0.0,0.0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="35"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="4"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.13">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_barbed"
+		name="{=qEcDWNci}Barbed Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_g"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="arrow_bl_g_quiver"
+		holster_mesh_with_weapon="arrow_bl_g_quiver"
+		subtype="arrows"
+		flying_mesh="arrow_bl_flying"
+		weight="0.05"
+		difficulty="0"
+		appearance="1"
+		Type="Arrows"
+		item_holsters="quiver_back_top:quiver_back_top_2"
+		holster_position_shift="0,0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="35"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_top"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.0,-0.13"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		id="mp_arrows_barbed_extra"
+		name="{=qEcDWNci}Barbed Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_g"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="arrow_bl_g_quiver"
+		holster_mesh_with_weapon="arrow_bl_g_quiver"
+		subtype="arrows"
+		flying_mesh="arrow_bl_flying"
+		weight="0.05"
+		difficulty="0"
+		appearance="1"
+		Type="Arrows"
+		item_holsters="quiver_back_top:quiver_back_top_2"
+		holster_position_shift="0,0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="50"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_top"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.0,-0.13"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		id="mp_arrows_barbed_mounted"
+		name="{=qEcDWNci}Barbed Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_g"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="arrow_bl_g_quiver"
+		holster_mesh_with_weapon="arrow_bl_g_quiver"
+		subtype="arrows"
+		flying_mesh="arrow_bl_flying"
+		weight="0.05"
+		difficulty="0"
+		appearance="1"
+		Type="Arrows"
+		item_holsters="quiver_back_top:quiver_back_top_2"
+		holster_position_shift="0,0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="32"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="0"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_top"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0.0,-0.13"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		id="mp_arrows_barbed_strong"
+		name="{=7jemQg2V}Heavy Barbed Arrow"
+		body_name="bo_capsule_arrow"
+		holster_body_name="bo_axe_short"
+		mesh="arrow_bl_c"
+		value="1"
+		is_merchandise="false"
+		holster_mesh="arrow_bl_c_quiver"
+		holster_mesh_with_weapon="arrow_bl_c_quiver"
+		weight="0.06"
+		flying_mesh="arrow_bl_flying"
+		appearance="1"
+		Type="Arrows"
+		item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts"
+		holster_position_shift="0.0,0.0,0.15">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="35"
+				thrust_speed="0"
+				speed_rating="0"
+				physics_material="missile"
+				missile_speed="10"
+				weapon_length="97"
+				thrust_damage="4"
+				thrust_damage_type="Pierce"
+				item_usage="arrow_right"
+				passby_sound_code="event:/mission/combat/missile/passby"
+				rotation="0, -80, 25"
+				sticking_position="0,-0.97,0"
+				sticking_rotation="90,0,0"
+				center_of_mass="0,0,-0.13"
+				modifier_group="arrow">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<!--Aserai End-->
+	<!-- #endregion -->
+	<!-- #region Shields -->
+	<Item
+		id="mp_strapped_round_shield"
+		name="{=EXLY9mEb}Reinforced Large Round Shield"
+		body_name="bo_cap_sturgia_shield_a"
+		shield_body_name="bo_sturgia_shield_c"
+		recalculate_body="false"
+		mesh="sturgia_shield_c"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		difficulty="0"
+		appearance="0.6"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0,0,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.02, 0.0, 0.0"
+				rotation="-15.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0, 0, 0"
+				hit_points="150">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		id="mp_noyans_shield"
+		name="{=C077yplu}Decorated Khuzait Shield"
+		body_name="bo_cap_shield_khuzait_cavalary_c"
+		shield_body_name="bo_shield_khuzait_cavalary_c"
+		recalculate_body="false"
+		mesh="shield_khuzait_cavalary_c"
+		value="1"
+		is_merchandise="false"
+		using_tableau="true"
+		weight="4.7"
+		appearance="0.9"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="25"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="metal_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0,0.075,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_wide_heater_shield"
+		name="{=OhEQUMk0}Wide Heater Shield"
+		body_name="bo_cap_heater_shield_i"
+		shield_body_name="bo_heater_shield_i"
+		recalculate_body="false"
+		mesh="heater_shield_i"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="90"
+				center_of_mass="-0.0,0.2,0.05"
+				hit_points="140">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_worn_kite_shield"
+		name="{=dacwWKE2}Worn Kite Shield"
+		body_name="bo_cap_kite_shield_b"
+		shield_body_name="bo_kite_shield_b"
+		recalculate_body="false"
+		mesh="kite_shield_b"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.0,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_damage_type="Blunt"
+				thrust_speed="82"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="128"
+				hit_points="80"
+				center_of_mass="0,-0.1,0.1">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_old_kite_sparring_shield"
+		name="{=cDetN1Ao}Makeshift Kite Sparring Shield"
+		body_name="bo_cap_kite_shield_a"
+		shield_body_name="bo_kite_shield_a"
+		recalculate_body="false"
+		mesh="kite_shield_a"
+		using_tableau="true"
+		weight="1"
+		value="1"
+		is_merchandise="false"
+		appearance="0.3"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,0,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="1"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="170"
+				center_of_mass="0.0,0.05,0.05"
+				hit_points="130"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_heavy_heater_shield"
+		name="{=rF7Xm7C0}Heavy Heater Shield"
+		body_name="bo_cap_heater_shield_g"
+		shield_body_name="bo_heater_shield_g"
+		recalculate_body="false"
+		mesh="heater_shield_g"
+		culture="Culture.vlandia"
+		using_tableau="true"
+		weight="2"
+		value="1"
+		is_merchandise="false"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,0,0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="100"
+				center_of_mass="0.0,0.05,0.05"
+				hit_points="310"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_western_kite_shield"
+		name="{=uqO6e6vN}Kite Shield"
+		body_name="bo_cap_shield_vlandia_infantary_a"
+		shield_body_name="bo_shield_vlandia_infantary_a"
+		recalculate_body="false"
+		mesh="shield_vlandia_infantary_a"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.08,0.1,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="110"
+				center_of_mass="-0.070,0.0,0.05"
+				hit_points="120">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tall_heater_shield"
+		name="{=Lbm7asY3}Tall Heater Shield"
+		body_name="bo_cap_heater_shield_k"
+		shield_body_name="bo_heater_shield_k"
+		recalculate_body="false"
+		mesh="heater_shield_k"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="105"
+				center_of_mass="-0.0,0.1,0.05"
+				hit_points="245">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tall_heater_shield_light"
+		name="{=8bH8n3Aq}Light Tall Heater Shield"
+		body_name="bo_cap_heater_shield_k"
+		shield_body_name="bo_heater_shield_k"
+		recalculate_body="false"
+		mesh="heater_shield_k"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="9"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="105"
+				center_of_mass="-0.0,0.1,0.05"
+				hit_points="135">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_pavise_shield"
+		name="{=aVGSZhCN}Pavise Shield"
+		body_name="bo_cap_kite_shield_e"
+		shield_body_name="bo_kite_shield_e"
+		recalculate_body="false"
+		mesh="kite_shield_e"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.0"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="118"
+				center_of_mass="0.0,0.1,0.1"
+				hit_points="160">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_western_riders_kite_shield"
+		name="{=FxnFBhrF}Cavalry Kite Shield"
+		body_name="bo_cap_shield_vlandia_cavalary_a"
+		shield_body_name="bo_shield_vlandia_cavalary_a"
+		recalculate_body="false"
+		mesh="shield_vlandia_cavalary_a"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="85"
+				center_of_mass="0.0,0.1,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_horsemans_kite_shield"
+		name="{=radJHwRW}Heavy Horseman Kite Shield"
+		body_name="bo_cap_kite_shield_n"
+		shield_body_name="bo_kite_shield_n"
+		recalculate_body="false"
+		mesh="kite_shield_n"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.9"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="78"
+				center_of_mass="0.0,0.1,0.1"
+				hit_points="130">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_viking_round_shield"
+		name="{=it3sDnGw}Sturgian Round Shield"
+		body_name="bo_cap_shield_sturgia_infantary_a"
+		shield_body_name="bo_shield_sturgia_infantary_a"
+		recalculate_body="false"
+		mesh="shield_sturgia_infantary_a"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="3.5"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0.0,0,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.02, 0.0, 0.0"
+				rotation="-15.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0.0,0.065,0.05"
+				hit_points="125">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_worn_horsemans_kite_shield"
+		name="{=TV02bZ4t}Worn Horseman Kite Shield"
+		body_name="bo_cap_kite_shield_g"
+		shield_body_name="bo_kite_shield_g"
+		recalculate_body="false"
+		mesh="kite_shield_g"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.0"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0.035">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="78"
+				center_of_mass="0.0,0.1,0.0"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_ironrim_kite_shield"
+		name="{=isuBaIqQ}Ironrimmed Kite Shield"
+		body_name="bo_cap_shield_vlandia_infantary_b"
+		shield_body_name="bo_shield_vlandia_infantary_b"
+		recalculate_body="false"
+		mesh="shield_vlandia_infantary_b"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="110"
+				center_of_mass="-0.070,0.0,0.05"
+				hit_points="140">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_highland_scouts_shield"
+		name="{=GEHTam8H}Battanian Scout Shield"
+		body_name="bo_cap_shield_battania_cavalary_a"
+		shield_body_name="bo_shield_battania_cavalary_a"
+		recalculate_body="false"
+		mesh="shield_battania_cavalary_a"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,-0.04">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0,0.055,0.05"
+				hit_points="140">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_leather_round_shield"
+		name="{=WYFDXE82}Large Round Shield"
+		body_name="bo_cap_sturgia_shield_a"
+		shield_body_name="bo_sturgia_shield_b"
+		recalculate_body="false"
+		mesh="sturgia_shield_b"
+		culture="Culture.sturgia"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		difficulty="0"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0,0,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.02, 0.0, 0.0"
+				rotation="-15.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0, 0.15, 0"
+				hit_points="250">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		id="mp_leather_round_shield_light"
+		name="{=IKhu13vZ}Light Round Shield"
+		body_name="bo_cap_sturgia_shield_a"
+		shield_body_name="bo_sturgia_shield_a"
+		recalculate_body="false"
+		mesh="sturgia_shield_a"
+		culture="Culture.sturgia"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.8"
+		difficulty="0"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0 ,0 ,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="8"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.005, 0.0, 0.0"
+				rotation="-5.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0, 0.15, 0"
+				hit_points="190">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_curved_round_shield"
+		name="{=hE8s9bpP}Curved Round Shield"
+		using_tableau="true"
+		body_name="bo_cap_aserai_shields_e"
+		shield_body_name="bo_aserai_shields_e"
+		recalculate_body="false"
+		mesh="aserai_shields_e"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="5"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.07,-0.1,-0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="66"
+				center_of_mass="-0.0, 0.1, 0.1"
+				hit_points="100">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_decorated_steppe_shield"
+		name="{=oppGd4nH}Round Khuzait Shield"
+		body_name="bo_cap_shield_khuzait_cavalary_b"
+		shield_body_name="bo_shield_khuzait_cavalary_b"
+		recalculate_body="false"
+		mesh="shield_khuzait_cavalary_b"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0,0.075,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_round_shield"
+		name="{=hj563EZr}Studded Round Shield"
+		using_tableau="true"
+		body_name="bo_cap_aserai_shields_f"
+		shield_body_name="bo_aserai_shields_f"
+		recalculate_body="false"
+		mesh="aserai_shields_f"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.5"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0, 0.1, 0.1"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_northern_scouts_shield"
+		name="{=xYC1bkr7}Sturgian Kite Shield"
+		body_name="bo_cap_shield_sturgia_cavalary_a"
+		shield_body_name="bo_cap_shield_sturgia_cavalary_a"
+		recalculate_body="false"
+		mesh="shield_sturgia_cavalary_a"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="78"
+				center_of_mass="0.0,0.1,0.05"
+				hit_points="100">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_ironrim_riders_kite_shield"
+		name="{=dWr3nuBq}Reinforced Iron Rimmed Kite Shield"
+		body_name="bo_cap_shield_vlandia_cavalary_b"
+		shield_body_name="bo_shield_vlandia_cavalary_b"
+		recalculate_body="false"
+		mesh="shield_vlandia_cavalary_b"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		appearance="0.6"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="85"
+				center_of_mass="0.0,0.1,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_leather_bound_kite_shield"
+		name="{=Ita1lG33}Leather Bound Kite Shield"
+		body_name="bo_cap_kite_shield_c"
+		shield_body_name="bo_kite_shield_c"
+		recalculate_body="false"
+		mesh="kite_shield_c"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		appearance="0.5"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,0,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="128"
+				center_of_mass="0.0,0.05,0.05"
+				hit_points="80">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_tribal_steppe_shield"
+		name="{=TB6NGI82}Tribal Khuzait Shield"
+		body_name="bo_cap_shield_khuzait_cavalary_a"
+		shield_body_name="bo_shield_khuzait_cavalary_a"
+		recalculate_body="false"
+		mesh="shield_khuzait_cavalary_a"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0,0.075,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_footmans_wicker_shield"
+		name="{=mDHMOUdx}Footman Wicker Shield"
+		body_name="bo_cap_shield_khuzait_infantary_b"
+		shield_body_name="bo_shield_khuzait_infantary_b"
+		recalculate_body="false"
+		mesh="shield_khuzait_infantary_b"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="95"
+				center_of_mass="-0.0,0.25,0.05"
+				hit_points="230">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_targe_b"
+		name="{=MnmUBlbL}Targe"
+		using_tableau="true"
+		body_name="bo_cap_battania_targe_b"
+		shield_body_name="bo_battania_targe_b"
+		recalculate_body="false"
+		mesh="battania_targe_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.5"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0.0,0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="8"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.18, -0.04, 0.00"
+				rotation="-5.90,19.00,38.50"
+				weapon_length="77"
+				center_of_mass="-0.035,0.1,0.05"
+				hit_points="130">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_small_flat_heater_shield"
+		name="{=Ai7qIb9I}Small Heater Shield"
+		body_name="bo_cap_heater_shield_h"
+		shield_body_name="bo_heater_shield_h"
+		recalculate_body="false"
+		mesh="heater_shield_h"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="1"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.08,0,0.0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="1"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="77"
+				center_of_mass="-0.035,0.1,0.05"
+				hit_points="20">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bound_desert_round_shield"
+		name="{=uvmmBd41}Bound Desert Round Shield"
+		using_tableau="true"
+		body_name="bo_cap_aserai_shields_d"
+		shield_body_name="bo_aserai_shields_d"
+		recalculate_body="false"
+		mesh="aserai_shields_d"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.0"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.12,-0.15,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0, 0.0, 0.1"
+				hit_points="140">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_large_shield_a"
+		name="{=eEMgc7yU}Battanian Reinforced Large Shield"
+		body_name="bo_cap_battania_large_shield_a"
+		shield_body_name="bo_battania_large_shield_a"
+		recalculate_body="false"
+		mesh="mp_battania_large_shield_a"
+		using_tableau="true"
+		weight="1.2"
+		value="1"
+		is_merchandise="false"
+		appearance="1.1"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0.0,0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="0.05, -0.01, 0.00"
+				rotation="-75.00,-62.90,0.00"
+				weapon_length="150"
+				center_of_mass="0.0,0.065,0.05"
+				hit_points="140"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_large_shield_b"
+		name="{=OnpIGPEG}Battanian Large Bronze Shield"
+		body_name="bo_cap_battania_large_shield_b"
+		shield_body_name="bo_battania_large_shield_b"
+		recalculate_body="false"
+		mesh="mp_battania_large_shield_b"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		appearance="1"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0.0,0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="0.04, -0.01, 0.0"
+				rotation="-75.00,-62.90,0.00"
+				weapon_length="150"
+				center_of_mass="0.0,0.065,0.05"
+				hit_points="90"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_oval_shield"
+		name="{=WyxIVvhe}Aserai Oval Shield"
+		body_name="bo_cap_shield_aserai_infantary_a"
+		shield_body_name="bo_shield_aserai_infantary_a"
+		recalculate_body="false"
+		mesh="shield_aserai_infantary_a"
+		culture="Culture.neutral_culture"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="1.2"
+		Type="Shield"
+		item_holsters="shield_oval:shield_4:shield_3:shield_2"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.04,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="110"
+				center_of_mass="-0.035, 0.1, 0.1"
+				hit_points="100">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_oval_shield"
+		name="{=927d3urB}Wooden Oval Shield"
+		body_name="bo_cap_aserai_shields_b"
+		shield_body_name="bo_aserai_shields_b"
+		recalculate_body="false"
+		mesh="aserai_shields_b"
+		using_tableau="true"
+		weight="2.1"
+		appearance="0.7"
+		value="1"
+		is_merchandise="false"
+		Type="Shield"
+		item_holsters="shield_oval:shield_4:shield_3:shield_2"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.04,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="132"
+				center_of_mass="0, 0.1, 0.1"
+				hit_points="140">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bound_adarga"
+		name="{=t1HEYuSD}Bound Adarga"
+		using_tableau="true"
+		body_name="bo_cap_aserai_shields_h"
+		shield_body_name="bo_aserai_shields_h"
+		recalculate_body="false"
+		mesh="aserai_shields_h"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="3.7"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="0.0,0.05,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_round_shield"
+		name="{=uEcbnd5D}Round Shield"
+		using_tableau="true"
+		body_name="bo_cap_aserai_shields_c"
+		shield_body_name="bo_aserai_shields_c"
+		recalculate_body="false"
+		mesh="aserai_shields_c"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.12,-0.2,-0.08">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="70"
+				center_of_mass="-0.0, 0.0, 0.1"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_old_horsemans_kite_shield"
+		name="{=8qwg1gr3}Old Horseman Kite Shield"
+		body_name="bo_cap_kite_shield_f"
+		shield_body_name="bo_kite_shield_f"
+		recalculate_body="false"
+		mesh="kite_shield_f"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		culture="Culture.neutral_culture"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0.035">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="78"
+				center_of_mass="0.0,0.05,0.0"
+				hit_points="100">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_round_shield"
+		name="{=it3sDnGw}Sturgian Round Shield"
+		body_name="bo_cap_shield_sturgia_infantary_b"
+		shield_body_name="bo_shield_sturgia_infantary_b"
+		recalculate_body="false"
+		mesh="shield_sturgia_infantary_b"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		culture="Culture.neutral_culture"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0.0,0,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.02, 0.02, 0.0"
+				rotation="175.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0.0,0.065,0.05"
+				hit_points="130">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		id="mp_sturgia_old_shield_a"
+		name="{=RddFH0BA}Iron Rimmed Large Round Shield"
+		body_name="bo_cap_sturgia_old_shield"
+		shield_body_name="bo_sturgia_old_shield"
+		recalculate_body="false"
+		mesh="sturgia_old_shield_a"
+		culture="Culture.sturgia"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		difficulty="0"
+		appearance="1"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0,0,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.02, 0.0, 0.0"
+				rotation="-15.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0, 0, 0"
+				hit_points="200"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		id="mp_sturgia_old_shield_b"
+		name="{=nTjEUF9z}Crude Large Round Shield"
+		body_name="bo_cap_sturgia_old_shield"
+		shield_body_name="bo_sturgia_old_shield"
+		recalculate_body="false"
+		mesh="sturgia_old_shield_b"
+		culture="Culture.sturgia"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		difficulty="0"
+		appearance="1"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="0,0,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="0"
+				thrust_speed="82"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="hand_shield"
+				position="-0.02, 0.0, 0.0"
+				rotation="-15.0,-90.0,-10.0"
+				weapon_length="70"
+				center_of_mass="0, 0, 0"
+				hit_points="200"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			ForceAttachOffHandPrimaryItemBone="true"
+			HeldInOffHand="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_reinforced_horsemans_kite_shield"
+		name="{=HEsETRqw}Reinforced Horseman Kite Shield"
+		body_name="bo_cap_kite_shield_j"
+		shield_body_name="bo_kite_shield_j"
+		recalculate_body="false"
+		mesh="kite_shield_j"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="5.8"
+		culture="Culture.neutral_culture"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="5"
+				thrust_damage="5"
+				thrust_damage_type="Blunt"
+				thrust_speed="82"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="78"
+				hit_points="105"
+				center_of_mass="0, 0, 0">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steel_round_shield"
+		name="{=FktkkUMK}Steel Round Shield"
+		body_name="bo_cap_aserai_shields_g"
+		shield_body_name="bo_aserai_shields_g"
+		recalculate_body="false"
+		mesh="aserai_shields_g"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="4"
+		appearance="0.9"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.07,-0.05">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="30"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="metal_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="0.01, 0.07, 0.1"
+				hit_points="200"
+				modifier_group="shield_metal">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_heavy_oval_shield"
+		name="{=iPfZpGHK}Heavy Oval Shield"
+		body_name="bo_cap_aserai_shields_a"
+		shield_body_name="bo_aserai_shields_a"
+		recalculate_body="false"
+		mesh="aserai_shields_a"
+		using_tableau="true"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		Type="Shield"
+		item_holsters="shield_oval:shield_4:shield_3:shield_2"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.04,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="135"
+				center_of_mass="0, 0, 0"
+				hit_points="240">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_light_oval_shield"
+		name="{=4aFPp5hj}Light Oval Shield"
+		body_name="bo_cap_aserai_shields_a"
+		shield_body_name="bo_aserai_shields_a"
+		recalculate_body="false"
+		mesh="aserai_shields_b"
+		using_tableau="true"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="2"
+		Type="Shield"
+		item_holsters="shield_oval:shield_4:shield_3:shield_2"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.04,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="89"
+				thrust_damage_type="Blunt"
+				speed_rating="89"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="135"
+				center_of_mass="0, 0, 0"
+				hit_points="160">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_highland_riders_shield"
+		name="{=SZmyhMO2}Battanian Cavalry Shield"
+		body_name="bo_cap_shield_battania_cavalary_a"
+		shield_body_name="bo_shield_battania_cavalary_b"
+		recalculate_body="false"
+		mesh="shield_battania_cavalary_b"
+		using_tableau="true"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="Shield"
+		item_holsters="shield_round:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,-0.04">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0,0.055,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_horsemans_shield"
+		name="{=nbjUGjaZ}Sturgian Horseman Shield"
+		body_name="bo_cap_shield_sturgia_cavalary_b"
+		shield_body_name="bo_shield_sturgia_cavalary_b"
+		recalculate_body="false"
+		mesh="shield_sturgia_cavalary_b"
+		using_tableau="true"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="78"
+				center_of_mass="0.0,0.1,0.05"
+				hit_points="105">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_emirs_oval_shield"
+		name="{=G7AEWZ6c}Decorated Oval Shield"
+		body_name="bo_cap_shield_aserai_infantary_c"
+		shield_body_name="bo_shield_aserai_infantary_c"
+		recalculate_body="false"
+		mesh="shield_aserai_infantary_c"
+		using_tableau="true"
+		weight="2.3"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		Type="Shield"
+		item_holsters="shield_oval:shield_4:shield_3:shield_2"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.04,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="110"
+				center_of_mass="-0.035, 0.1, 0.1"
+				hit_points="160">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_southern_oval_shield"
+		name="{=8nNLS96w}Reinforced Oval Shield"
+		body_name="bo_cap_shield_aserai_infantary_b"
+		shield_body_name="bo_shield_aserai_infantary_b"
+		recalculate_body="false"
+		mesh="shield_aserai_infantary_b"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="4.7"
+		appearance="0.8"
+		Type="Shield"
+		item_holsters="shield_oval:shield_4:shield_3:shield_2"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.04,-0.0,0">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="110"
+				center_of_mass="-0.035, 0.1, 0.1"
+				hit_points="125">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_stronger_reinforced_kite_shield"
+		name="{=OM9achAa}Reinforced Oaken Kite Shield"
+		body_name="bo_cap_kite_shield_d"
+		shield_body_name="bo_kite_shield_d"
+		recalculate_body="false"
+		mesh="kite_shield_d"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,0,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="20"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="128"
+				center_of_mass="0.0,0.05,0.05"
+				hit_points="240">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_reinforced_flat_kite_shield"
+		name="{=A1zFbFta}Reinforced Flat Kite Shield"
+		body_name="bo_cap_kite_shield_p"
+		shield_body_name="bo_kite_shield_p"
+		recalculate_body="false"
+		mesh="kite_shield_p"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		appearance="0.6"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.0,0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="110"
+				center_of_mass="0.0,0.0,0.0"
+				hit_points="150"
+				modifier_group="shield_wood">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_lighter_reinforced_kite_shield"
+		name="{=CJCatm7j}Lighter Oaken Kite Shield"
+		body_name="bo_cap_kite_shield_d"
+		shield_body_name="bo_kite_shield_d"
+		recalculate_body="false"
+		mesh="kite_shield_d"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		appearance="0.7"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,0,-0.025">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				physics_material="wood_shield"
+				weapon_length="128"
+				center_of_mass="0.0,0.05,0.05"
+				hit_points="130">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_steppe_guardian_shield"
+		name="{=PPpvY6BZ}Khuzait Cavalry Shield"
+		body_name="bo_cap_shield_khuzait_cavalary_d"
+		shield_body_name="bo_shield_khuzait_cavalary_d"
+		recalculate_body="false"
+		mesh="shield_khuzait_cavalary_d"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		appearance="0.9"
+		Type="Shield"
+		item_holsters="shield_kite:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.05,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="25"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="60"
+				center_of_mass="-0.0,0.075,0.05"
+				hit_points="100">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_eastern_wicker_shield"
+		name="{=pEaYQqG9}Wicker Square Shield"
+		body_name="bo_cap_shield_khuzait_infantary_a"
+		shield_body_name="bo_shield_khuzait_infantary_a"
+		recalculate_body="false"
+		mesh="shield_khuzait_infantary_a"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		appearance="0.5"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="10"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="90"
+				center_of_mass="-0.0,0.25,0.05"
+				hit_points="150">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<Item
+		id="mp_stronger_eastern_wicker_shield"
+		name="{=F9HQABfN}Reinforced Wicker Square Shield"
+		body_name="bo_cap_shield_khuzait_infantary_a"
+		shield_body_name="bo_shield_khuzait_infantary_b"
+		recalculate_body="false"
+		mesh="shield_khuzait_infantary_b"
+		using_tableau="true"
+		value="1"
+		is_merchandise="false"
+		weight="2.7"
+		appearance="0.5"
+		Type="Shield"
+		item_holsters="shield:shield_2:shield_3:shield_4"
+		has_lower_holster_priority="true"
+		holster_position_shift="-0.1,-0.1,0.01">
+		<ItemComponent>
+			<Weapon
+				weapon_class="LargeShield"
+				body_armor="15"
+				thrust_speed="82"
+				thrust_damage_type="Blunt"
+				speed_rating="82"
+				physics_material="wood_shield"
+				item_usage="shield"
+				position="0.0, 0.00, 0.00"
+				rotation="0.0,10.0,40.00"
+				weapon_length="90"
+				center_of_mass="-0.0,0.25,0.05"
+				hit_points="230">
+				<WeaponFlags
+					CanBlockRanged="true"
+					HasHitPoints="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			WoodenParry="true"
+			HeldInOffHand="true"
+			ForceAttachOffHandSecondaryItemBone="true" />
+	</Item>
+	<!-- #endregion -->
+	<!-- #endregion -->
+	<!-- #region Horses -->
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_horse"
+		name="{=AIu3kKvz}Saddle Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="sumpter_horse"
+		value="1"
+		is_merchandise="false"
+		weight="400"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="61"
+				speed="41"
+				charge_damage="4"
+				body_length="104"
+				is_mountable="true"
+				extra_health="15"
+				skeleton_scale="vlandia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_horse_faster"
+		name="{=hunterhorse}Hunter"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="sumpter_horse"
+		value="1"
+		is_merchandise="false"
+		weight="390"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="65"
+				speed="46"
+				charge_damage="3"
+				body_length="103"
+				is_mountable="true"
+				extra_health="15"
+				skeleton_scale="vlandia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_horse_agile"
+		name="{=BDGbu59Q}Jaculan Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="sumpter_horse"
+		value="1"
+		is_merchandise="false"
+		weight="385"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="72"
+				speed="43"
+				charge_damage="3"
+				body_length="104"
+				is_mountable="true"
+				extra_health="15"
+				skeleton_scale="vlandia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_horse_war"
+		name="{=h5kfaD4v}Charger"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="420"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="65"
+				speed="38"
+				charge_damage="7"
+				body_length="113"
+				is_mountable="true"
+				extra_health="60"
+				skeleton_scale="vlandia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_horse_war_tougher"
+		name="{=I1faIdpc}Brawler"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="420"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="63"
+				speed="38"
+				charge_damage="9"
+				body_length="113"
+				is_mountable="true"
+				extra_health="100"
+				skeleton_scale="vlandia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandia_horse_war_faster"
+		name="{=JfPqJbK6}Faster Charger"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="410"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="69"
+				speed="42"
+				charge_damage="7"
+				body_length="111"
+				is_mountable="true"
+				extra_health="75"
+				skeleton_scale="vlandia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_horse"
+		name="{=zNoDVcHg}Trotter"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="400"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="60"
+				speed="44"
+				charge_damage="4"
+				body_length="100"
+				is_mountable="true"
+				extra_health="5"
+				skeleton_scale="sturgia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_horse_agile"
+		name="{=Ejx5lXjk}Sturgian Chaser"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="405"
+		difficulty="0"
+		appearance="1"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="74"
+				speed="41"
+				charge_damage="6"
+				body_length="102"
+				is_mountable="true"
+				extra_health="80"
+				skeleton_scale="sturgia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+		<Flags
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_horse_war"
+		name="{=jhgVsWKr}Tyal Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="420"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="66"
+				speed="40"
+				charge_damage="6"
+				body_length="110"
+				is_mountable="true"
+				extra_health="80"
+				skeleton_scale="sturgia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_horse_tougher"
+		name="{=MUdwS6jH}Tougher Tyal Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="420"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="64"
+				speed="39"
+				charge_damage="9"
+				body_length="112"
+				is_mountable="true"
+				extra_health="100"
+				skeleton_scale="sturgia_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_saddle"
+		name="{=OeKwbpM7}Steppe Saddle Horse"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="430"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="64"
+				speed="38"
+				charge_damage="2"
+				body_length="92"
+				is_mountable="true"
+				extra_health="-5"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_saddle_thougher"
+		name="{=2xvB6XQP}Steppe Tough Horse"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="435"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="65"
+				speed="38"
+				charge_damage="5"
+				body_length="97"
+				is_mountable="true"
+				extra_health="30"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse"
+		name="{=YAYhozbN}Steppe Horse"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="380"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="68"
+				speed="41"
+				charge_damage="4"
+				body_length="95"
+				is_mountable="true"
+				extra_health="-15"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_agile"
+		name="{=a4hyzv3f}Tarpan"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="370"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="74"
+				speed="42"
+				charge_damage="6"
+				body_length="95"
+				is_mountable="true"
+				extra_health="-15"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_war"
+		name="{=PZPphq6H}Steppe Warhorse"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="390"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="69"
+				speed="39"
+				charge_damage="6"
+				body_length="100"
+				is_mountable="true"
+				extra_health="50"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_war_light"
+		name="{=8Sy6nZPs}Steppe Battlehorse"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="375"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="68"
+				speed="40"
+				charge_damage="6"
+				body_length="100"
+				is_mountable="true"
+				extra_health="60"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_tougher"
+		name="{=zKJtr0MV}Makeb Horse"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="395"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="72"
+				speed="39"
+				charge_damage="8"
+				body_length="102"
+				is_mountable="true"
+				extra_health="95"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_horse_charger"
+		name="{=igAT9Eqb}Steppe Charger"
+		mesh="horse_brown"
+		item_category="horse"
+		subtype="horse"
+		value="1"
+		is_merchandise="false"
+		weight="390"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="68"
+				speed="41"
+				charge_damage="9"
+				body_length="100"
+				is_mountable="true"
+				extra_health="-15"
+				skeleton_scale="khuzait_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="steppe_horse">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horse"
+		name="{=courserhorse}Courser"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="405"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="61"
+				speed="44"
+				charge_damage="4"
+				body_length="114"
+				is_mountable="true"
+				extra_health="15"
+				skeleton_scale="empire_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horse_agile"
+		name="{=IOt4KTHs}Midlands Palfrey"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="390"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="69"
+				speed="45"
+				charge_damage="4"
+				body_length="112"
+				is_mountable="true"
+				extra_health="15"
+				skeleton_scale="empire_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horse_faster"
+		name="{=kOV5t7Yx}Danustica Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="395"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="63"
+				speed="48"
+				charge_damage="4"
+				body_length="112"
+				is_mountable="true"
+				extra_health="15"
+				skeleton_scale="empire_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horse_war"
+		name="{=UG8aeEQH}Imperial Warhorse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="425"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="62"
+				speed="38"
+				charge_damage="7"
+				body_length="120"
+				is_mountable="true"
+				extra_health="95"
+				skeleton_scale="empire_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horse_war_agile"
+		name="{=Cw5N7rK6}War Courser"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="410"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="69"
+				speed="44"
+				charge_damage="7"
+				body_length="118"
+				is_mountable="true"
+				extra_health="90"
+				skeleton_scale="empire_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_white_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_grey_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_empire_horse_war_charger"
+		name="{=mVAaWp5U}Imperial Charger"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="425"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="62"
+				speed="40"
+				charge_damage="10"
+				body_length="118"
+				is_mountable="true"
+				extra_health="95"
+				skeleton_scale="empire_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_black_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horse"
+		name="{=84gnexLb}Desert horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="400"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="55"
+				speed="49"
+				charge_damage="4"
+				body_length="105"
+				is_mountable="true"
+				extra_health="-5"
+				skeleton_scale="aserai_horse"
+				modifier_group="horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horse_agile"
+		name="{=yPeC0Vgs}Nahasan"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="400"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="68"
+				speed="50"
+				charge_damage="4"
+				body_length="103"
+				is_mountable="true"
+				extra_health="0"
+				skeleton_scale="aserai_horse"
+				modifier_group="horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horse_war"
+		name="{=1X2X0Qe4}Barb Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="war_horse"
+		value="1"
+		is_merchandise="false"
+		weight="420"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="57"
+				speed="45"
+				charge_damage="7"
+				body_length="108"
+				is_mountable="true"
+				extra_health="65"
+				skeleton_scale="aserai_horse"
+				modifier_group="horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF303030"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horse_war_faster"
+		name="{=3WdXljdt}Tough Nahasan"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="war_horse"
+		value="1"
+		is_merchandise="false"
+		weight="410"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="59"
+				speed="49"
+				charge_damage="6"
+				body_length="105"
+				is_mountable="true"
+				extra_health="60"
+				skeleton_scale="aserai_horse"
+				modifier_group="horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_horse_war_agile"
+		name="{=O4agNHhn}Agile Barb Horse"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="war_horse"
+		value="1"
+		is_merchandise="false"
+		weight="405"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="65"
+				speed="46"
+				charge_damage="6"
+				body_length="106"
+				is_mountable="true"
+				extra_health="60"
+				skeleton_scale="aserai_horse"
+				modifier_group="horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="horse_brown_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_camel"
+		name="{=Goloz0Vm}Husnphree"
+		mesh="camel_mesh"
+		culture="Culture.neutral_culture"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="500"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.camel"
+				maneuver="70"
+				speed="40"
+				charge_damage="7"
+				body_length="95"
+				extra_health="70"
+				is_mountable="true" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_pony"
+		name="{=OL1oJ9j5}Dale Pony"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="370"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="62"
+				speed="42"
+				charge_damage="4"
+				body_length="97"
+				is_mountable="true"
+				extra_health="25"
+				skeleton_scale="battania_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="dales_pony_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="dales_pony_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_pony_agile"
+		name="{=veB9S1OI}Agile Dale Pony"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="horse"
+		value="1"
+		is_merchandise="false"
+		weight="360"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="72"
+				speed="44"
+				charge_damage="4"
+				body_length="96"
+				is_mountable="true"
+				extra_health="25"
+				skeleton_scale="battania_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="dales_pony_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="dales_pony_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_horse_war"
+		name="{=eQBDt5Wk}Fell Pony"
+		mesh="horse_brown"
+		subtype="horse"
+		item_category="war_horse"
+		value="1"
+		is_merchandise="false"
+		weight="390"
+		difficulty="0"
+		Type="Horse">
+		<ItemComponent>
+			<Horse
+				monster="Monster.horse"
+				maneuver="67"
+				speed="40"
+				charge_damage="8"
+				body_length="101"
+				is_mountable="true"
+				extra_health="70"
+				skeleton_scale="battania_horse">
+				<AdditionalMeshes>
+					<Mesh
+						name="horse_mane_2"
+						affected_by_cover="true" />
+					<Mesh
+						name="horse_trotter" />
+				</AdditionalMeshes>
+				<Materials>
+					<Material
+						name="dales_pony_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF08080B"
+								percentage="1.0" />
+						</MeshMultipliers>
+					</Material>
+					<Material
+						name="dales_pony_mat">
+						<MeshMultipliers>
+							<MeshMultiplier
+								mesh_multiplier="FF010101"
+								percentage="0.75" />
+							<MeshMultiplier
+								mesh_multiplier="FF909090"
+								percentage="0.25" />
+						</MeshMultipliers>
+					</Material>
+				</Materials>
+			</Horse>
+		</ItemComponent>
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Harnesses -->
+	<Item
+		multiplayer_item="true"
+		id="mp_light_harness"
+		name="{=O37kzdXO}Light Harness"
+		mesh="horse_harness_b"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				mane_cover_type="none"
+				maneuver_bonus="0"
+				speed_bonus="0"
+				charge_bonus="0"
+				family_type="1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_chain_barding"
+		name="{=aHQCG5Tn}Chain Barding"
+		mesh="horse_harness_vlandia_a_clotest"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="95"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_vlandia_a_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_light_harness"
+		name="{=IWv37ncp}Northlander Light Harness"
+		mesh="horse_harness_roman_b_new"
+		weight="30"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="leather"
+				reins_mesh="horse_harness_roman_b_new_rein"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_fur_harness"
+		name="{=ilLE877K}Steppe Fur Saddle "
+		mesh="horse_harness_khuzait_a_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_khuzait_a_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_half_barding"
+		name="{=0rzKQbWy}Steppe Half Barding"
+		mesh="horse_harness_khuzait_d_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="70"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_khuzait_d_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_steppe_harness"
+		name="{=vw9qbiER}Steppe Harness"
+		mesh="horse_harness_khuzait_b_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="30"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_khuzait_b_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_studded_steppe_barding"
+		name="{=lspv3mUE}Studded Steppe Barding"
+		mesh="horse_harness_khuzait_c_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="90"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="26"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_khuzait_c_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_stripped_leather_harness"
+		name="{=Yh7Dorsr}Striped Leather Harness"
+		mesh="horse_harness_imperial_a_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="leather"
+				reins_mesh="horse_harness_imperial_a_rein"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_scale_barding"
+		name="{=zmEnxUpL}Imperial Scale Barding"
+		mesh="horse_harness_imperial_b_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="95"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="26"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_imperial_b_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_half_scale_barding"
+		name="{=CgG2aRyh}Half Scale Barding"
+		mesh="horse_harness_imperial_c_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="70"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="16"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_imperial_c_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_cloth_harness"
+		name="{=2Q0m5CG0}Desert Cloth Harness"
+		mesh="horse_harness_aserai_a_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="cloth"
+				reins_mesh="horse_harness_aserai_a_rein"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aseran_village_harness"
+		name="{=4OT8Re4a}Desert Common Harness"
+		mesh="horse_harness_aserai_b_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				reins_mesh="horse_harness_aserai_b_rein"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="cloth"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_half_mail_and_plate_barding"
+		name="{=hCBCLp0e}Half Mail and Plate Barding"
+		mesh="horse_harness_aserai_d_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="70"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="plate"
+				reins_mesh="horse_harness_aserai_d_rein"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_mail_and_plate_barding"
+		name="{=gKhpLiyg}Mail and Plate Barding"
+		mesh="horse_harness_aserai_c_clotest"
+		culture="Culture.neutral_culture"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="95"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="28"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="plate"
+				reins_mesh="horse_harness_aserai_c_rein"
+				material_type="Plate" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_camel_saddle"
+		name="{=q1z4FQub}Camel Saddle"
+		mesh="camel_saddle1"
+		culture="Culture.neutral_culture"
+		value="1"
+		is_merchandise="false"
+		weight="30"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="0"
+				mane_cover_type="none"
+				family_type="2"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_ring_barding"
+		name="{=Hm7D4Z6v}Northlander Ring Barding"
+		mesh="horse_harness_sturgia_a_clotest"
+		value="1"
+		is_merchandise="false"
+		weight="70"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="15"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				reins_mesh="horse_harness_sturgia_a_rein"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_bandit_saddle_highland"
+		name="{=ZFde57gC}Rugged Highland Saddle"
+		mesh="bandit_saddle_highland"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="30"
+		difficulty="0"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="cloth"
+				reins_mesh="bandit_saddle_highland_rein"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_northern_noble_harness"
+		name="{=lZZOQsxc}Rough Cavalry Saddle"
+		mesh="horse_harness_sturgia_b_clotest"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				reins_mesh="horse_harness_sturgia_b_rein"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_horse_harness"
+		name="{=wrM9Km0n}Highland Horse Harness"
+		mesh="battania_horse_harness"
+		value="1"
+		is_merchandise="false"
+		weight="25"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				mane_cover_type="none"
+				family_type="1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_horse_harness_halfscaled"
+		name="{=LwxELoZL}Highland Half Scaled Horse Harness"
+		mesh="battania_horse_harness_halfscaled"
+		value="1"
+		is_merchandise="false"
+		weight="65"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="20"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_horse_harness_scaled"
+		name="{=OEbGMbG2}Highland Scaled Horse Harness"
+		mesh="battania_horse_harness_scaled"
+		value="1"
+		is_merchandise="false"
+		weight="120"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="20"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_imperial_riding_harness"
+		name="{=NUmDuEqI}Imperial Riding Harness"
+		mesh="horse_harness_a_new"
+		value="1"
+		is_merchandise="false"
+		weight="20"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				reins_mesh="horse_harness_a_new_rein"
+				mane_cover_type="all"
+				family_type="1"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_chain_horse_harness"
+		name="{=GTWUtUFj}Chain Horse Harness"
+		mesh="horse_harness_e"
+		subtype="body_armor"
+		value="1"
+		is_merchandise="false"
+		weight="95"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="28"
+				hair_cover_type="all"
+				covers_head="true"
+				mane_cover_type="all"
+				reins_mesh="horse_harness_e_rein"
+				maneuver_bonus="0"
+				speed_bonus="0"
+				charge_bonus="0"
+				family_type="1"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_halfchain_barding"
+		name="{=Yms2FQ7g}Halfchain Barding"
+		mesh="horse_harness_vlandia_b_clotest"
+		value="1"
+		is_merchandise="false"
+		weight="65"
+		culture="Culture.neutral_culture"
+		Type="HorseHarness">
+		<ItemComponent>
+			<Armor
+				body_armor="20"
+				mane_cover_type="all"
+				maneuver_bonus="0"
+				reins_mesh="horse_harness_vlandia_b_rein"
+				speed_bonus="0"
+				charge_bonus="0"
+				family_type="1"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+	</Item>
+	<!-- #endregion -->
+	<!-- #region Banner -->
+	<Item
+		id="mp_throwing_stone"
+		name="{=1CPdu9K0}Stone"
+		body_name="bo_throwing_stone_01"
+		holster_body_name="bo_axe_short"
+		holster_mesh="stone_holster"
+		holster_mesh_with_weapon="stone_holster"
+		mesh="throwing_stone"
+		value="1"
+		is_merchandise="false"
+		weight="0.1"
+		appearance="0.1"
+		Type="Thrown"
+		item_holsters="throwing_stone:throwing_stone_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Stone"
+				ammo_class="Stone"
+				stack_amount="15"
+				physics_material="missile"
+				accuracy="50"
+				thrust_speed="102"
+				speed_rating="102"
+				missile_speed="40"
+				weapon_length="10"
+				thrust_damage="15"
+				item_usage="stone"
+				rotation="100,30,20"
+				passby_sound_code=""
+				rotation_speed="0, -3.0, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					AutoReload="true"
+					UnloadWhenSheathed="true"
+					UseHandAsThrowBase="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="ballista_projectile"
+		name="{=6Db7aDbF}Ballista Arrows"
+		body_name="bo_ballista_projectile_a"
+		holster_body_name="bo_axe_short"
+		mesh="ballista_projectile_a"
+		holster_mesh="quiver"
+		subtype="arrows"
+		value="1"
+		is_merchandise="false"
+		weight="3"
+		difficulty="0"
+		appearance="0.5"
+		Type="Arrows"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="20"
+				physics_material="ballista_missile"
+				thrust_speed="0"
+				speed_rating="0"
+				missile_speed="80"
+				weapon_length="95"
+				thrust_damage="400"
+				thrust_damage_type="Pierce"
+				item_usage=""
+				flying_sound_code="event:/mission/combat/missile/foley/passby"
+				sticking_rotation="90,0,0"
+				sticking_position="0,-1.2,0"
+				center_of_mass="0,0,-0.3">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					MultiplePenetration="true"
+					CanPenetrateShield="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			CannotBePickedUp="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="ballista_projectile_burning"
+		name="{=6Db7aDbF}Ballista Arrows"
+		prefab="burning_ballista_projectile"
+		body_name="bo_ballista_projectile_a"
+		holster_body_name="bo_axe_short"
+		mesh="ballista_projectile_b"
+		holster_mesh="quiver"
+		subtype="arrows"
+		value="1"
+		is_merchandise="false"
+		weight="3"
+		difficulty="0"
+		appearance="0.5"
+		Type="Arrows"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Arrow"
+				stack_amount="20"
+				physics_material="burning_ballista"
+				thrust_speed="0"
+				speed_rating="0"
+				missile_speed="80"
+				weapon_length="95"
+				thrust_damage="400"
+				thrust_damage_type="Pierce"
+				item_usage=""
+				flying_sound_code="event:/mission/combat/missile/foley/passby"
+				trail_particle_name="psys_game_missile_flame"
+				sticking_rotation="90,0,0"
+				sticking_position="0,-1.2,0"
+				center_of_mass="0,0,-0.3">
+				<WeaponFlags
+					Consumable="true"
+					AmmoSticksWhenShot="true"
+					Burning="true"
+					MultiplePenetration="true"
+					LeavesTrail="true"
+					CanPenetrateShield="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			CannotBePickedUp="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="boulder"
+		name="{=pzfbPbWW}Boulder"
+		is_merchandise="false"
+		body_name="bo_projectile_rock"
+		holster_body_name="bo_axe_short"
+		mesh="projectile_rock"
+		holster_mesh=""
+		subtype="arrows"
+		value="1"
+		weight="15"
+		difficulty="0"
+		appearance="0.5"
+		Type="Thrown"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Boulder"
+				ammo_class="Boulder"
+				stack_amount="1"
+				position="0.05, -0.15, 0"
+				center_of_mass="0,0,0"
+				physics_material="boulder_stone"
+				thrust_speed="100"
+				speed_rating="0"
+				missile_speed="8"
+				weapon_length="95"
+				thrust_damage="70"
+				item_usage="heavy_stone"
+				flying_sound_code="event:/mission/combat/boulder/passby"
+				rotation_speed="2, 0.5, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					CanPenetrateShield="true"
+					MissileWithPhysics="true"
+					UseHandAsThrowBase="true"
+					LeavesTrail="true"
+					AmmoCanBreakOnBounceBack="true"
+					CanKillEvenIfBlunt="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			QuickFadeOut="true"
+			CannotBePickedUp="true"
+			DropOnWeaponChange="true"
+			DropOnAnyAction="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="pot"
+		name="{=3Wzhxkn1}Pot"
+		is_merchandise="false"
+		body_name="bo_projectile_rock"
+		holster_body_name="bo_axe_short"
+		flying_mesh="projectile_pot"
+		mesh="projectile_pot"
+		holster_mesh=""
+		subtype="arrows"
+		value="1"
+		weight="15"
+		difficulty="0"
+		appearance="0.5"
+		Type="Thrown"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Boulder"
+				ammo_class="Boulder"
+				stack_amount="1"
+				position="0.05, -0.15, 0"
+				physics_material="burning_jar"
+				thrust_speed="100"
+				speed_rating="0"
+				missile_speed="8"
+				weapon_length="95"
+				thrust_damage="70"
+				item_usage="heavy_stone"
+				flying_sound_code="event:/mission/combat/boulder/passby"
+				trail_particle_name="psys_game_burning_jar_trail"
+				rotation_speed="2, 0.5, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					CanPenetrateShield="true"
+					MissileWithPhysics="true"
+					Consumable="true"
+					LeavesTrail="true"
+					Burning="true"
+					AffectsAreaBig="true"
+					AmmoBreaksOnBounceBack="true"
+					CanKillEvenIfBlunt="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			QuickFadeOut="true"
+			CannotBePickedUp="true"
+			DropOnWeaponChange="true"
+			DropOnAnyAction="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="grapeshot_stack"
+		name="{=ZeU1fvdz}Grapeshot Stack"
+		body_name="bo_projectile_grapeshot_carry"
+		holster_body_name="bo_axe_short"
+		mesh="projectile_grapeshot_carry"
+		holster_mesh=""
+		subtype="arrows"
+		weight="15"
+		value="1"
+		is_merchandise="false"
+		difficulty="0"
+		appearance="1"
+		Type="Thrown"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Boulder"
+				ammo_class="Boulder"
+				stack_amount="1"
+				position="0.05, -0.15, 0"
+				center_of_mass="0,0,0"
+				physics_material="boulder_stone"
+				thrust_speed="100"
+				speed_rating="0"
+				missile_speed="8"
+				weapon_length="95"
+				thrust_damage="70"
+				item_usage="heavy_stone"
+				flying_sound_code="event:/mission/combat/boulder/passby"
+				rotation_speed="2, 0.5, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					CanPenetrateShield="true"
+					CanKnockDown="true"
+					MissileWithPhysics="true"
+					UseHandAsThrowBase="true"
+					LeavesTrail="true"
+					AmmoCanBreakOnBounceBack="true"
+					CanKillEvenIfBlunt="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			QuickFadeOut="true"
+			CannotBePickedUp="true"
+			DropOnWeaponChange="true"
+			DropOnAnyAction="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="grapeshot_fire_stack"
+		name="{=ZeU1fvdz}Grapeshot Stack"
+		body_name="bo_projectile_grapeshot_carry"
+		holster_body_name="bo_axe_short"
+		mesh="projectile_grapeshot_carry"
+		holster_mesh=""
+		subtype="arrows"
+		value="1"
+		is_merchandise="false"
+		weight="15"
+		difficulty="0"
+		appearance="1"
+		Type="Thrown"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Boulder"
+				ammo_class="Boulder"
+				stack_amount="1"
+				position="0.05, -0.15, 0"
+				center_of_mass="0,0,0"
+				physics_material="boulder_stone"
+				thrust_speed="100"
+				speed_rating="0"
+				missile_speed="8"
+				weapon_length="95"
+				thrust_damage="70"
+				item_usage="heavy_stone"
+				flying_sound_code="event:/mission/combat/boulder/passby"
+				rotation_speed="2, 0.5, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					CanPenetrateShield="true"
+					CanKnockDown="true"
+					MissileWithPhysics="true"
+					UseHandAsThrowBase="true"
+					LeavesTrail="true"
+					AmmoCanBreakOnBounceBack="true"
+					CanKillEvenIfBlunt="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			QuickFadeOut="true"
+			CannotBePickedUp="true"
+			DropOnWeaponChange="true"
+			DropOnAnyAction="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="grapeshot_projectile"
+		name="{=XGytILlt}Grapeshot Ammo"
+		body_name="bo_projectile_grapeshot_piece_a"
+		holster_body_name="bo_axe_short"
+		mesh="projectile_grapeshot_piece_a"
+		holster_mesh=""
+		subtype="arrows"
+		value="1"
+		is_merchandise="false"
+		weight="15"
+		difficulty="0"
+		appearance="1"
+		Type="Thrown"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Boulder"
+				ammo_class="Boulder"
+				stack_amount="1"
+				position="0.05, -0.15, 0"
+				center_of_mass="0,0,0"
+				physics_material="boulder_stone"
+				thrust_speed="100"
+				speed_rating="0"
+				missile_speed="8"
+				weapon_length="95"
+				thrust_damage="25"
+				item_usage="heavy_stone"
+				flying_sound_code="event:/mission/combat/boulder/passby"
+				rotation_speed="2, 0.5, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					CanPenetrateShield="true"
+					CanKnockDown="true"
+					MissileWithPhysics="true"
+					UseHandAsThrowBase="true"
+					LeavesTrail="true"
+					AmmoCanBreakOnBounceBack="true"
+					CanKillEvenIfBlunt="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			QuickFadeOut="true"
+			CannotBePickedUp="true"
+			DropOnWeaponChange="true"
+			DropOnAnyAction="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="grapeshot_fire_projectile"
+		name="{=XGytILlt}Grapeshot Ammo"
+		body_name="bo_projectile_grapeshot_piece_a"
+		holster_body_name="bo_axe_short"
+		mesh="projectile_grapeshot_piece_a"
+		holster_mesh=""
+		subtype="arrows"
+		value="1"
+		is_merchandise="false"
+		weight="15"
+		difficulty="0"
+		appearance="1"
+		Type="Thrown"
+		item_holsters="">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Boulder"
+				ammo_class="Boulder"
+				stack_amount="1"
+				position="0.05, -0.15, 0"
+				center_of_mass="0,0,0"
+				physics_material="boulder_stone"
+				thrust_speed="100"
+				speed_rating="0"
+				missile_speed="8"
+				weapon_length="95"
+				thrust_damage="25"
+				item_usage="heavy_stone"
+				flying_sound_code="event:/mission/combat/boulder/passby"
+				trail_particle_name="mangonel_grapeshot_burning_projectile"
+				rotation_speed="2, 0.5, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					NotUsableWithOneHand="true"
+					TwoHandIdleOnMount="true"
+					CanPenetrateShield="true"
+					CanKnockDown="true"
+					MissileWithPhysics="true"
+					UseHandAsThrowBase="true"
+					LeavesTrail="true"
+					Burning="true"
+					AffectsArea="true"
+					AmmoCanBreakOnBounceBack="true"
+					CanKillEvenIfBlunt="true" />
+			</Weapon>
+		</ItemComponent>
+		<Flags
+			QuickFadeOut="true"
+			CannotBePickedUp="true"
+			DropOnWeaponChange="true"
+			DropOnAnyAction="true" />
+	</Item>
+	<Item
+		id="mp_sling_stone"
+		name="{=bDfKz5SZ}Sling"
+		body_name="bo_throwing_stone_01"
+		holster_body_name="bo_axe_short"
+		holster_mesh="stone_holster"
+		holster_mesh_with_weapon="stone_holster"
+		mesh="throwing_stone"
+		value="1"
+		is_merchandise="false"
+		weight="0.1"
+		appearance="0.1"
+		Type="Thrown"
+		item_holsters="throwing_stone:throwing_stone_2">
+		<ItemComponent>
+			<Weapon
+				weapon_class="Stone"
+				ammo_class="Stone"
+				stack_amount="20"
+				physics_material="missile"
+				accuracy="88"
+				thrust_speed="102"
+				speed_rating="102"
+				missile_speed="45"
+				weapon_length="10"
+				thrust_damage="16"
+				item_usage="stone"
+				rotation="100,30,20"
+				passby_sound_code=""
+				rotation_speed="0, -3.0, 0">
+				<WeaponFlags
+					RangedWeapon="true"
+					Consumable="true"
+					AutoReload="true"
+					UseHandAsThrowBase="true"
+					UnloadWhenSheathed="true"
+					AmmoBreaksOnBounceBack="true" />
+			</Weapon>
+		</ItemComponent>
+	</Item>
+	<!-- #endregion -->
+	<!-- Missing Cosmetic Items from SP -->
+	<Item
+		multiplayer_item="true"
+		id="mp_cervelliere_over_padded_cap"
+		name="{=wG582fzT}Cervelliere over Padded Cap"
+		mesh="vlandia_helmet_n_e"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		appearance="1.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="20"
+				has_gender_variations="false"
+				hair_cover_type="type2"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_cloth_headwrap"
+		name="{=frwBm3Oh}Cloth Headwrap"
+		subtype="head_armor"
+		mesh="vlandia_helmet_d"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="6"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth"
+				beard_cover_type="all" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_full_helm_over_padded_cloth"
+		name="{=xnoAJwoy}Full Helm over Padded Cloth"
+		mesh="vlandia_helmet_s_y"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		appearance="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="48"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_guards_kettle_over_mail_coif"
+		name="{=S1SUK8zk}Kettle over Mail Coif"
+		mesh="vlandia_helmet_j_a"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="3.6"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_kettle_hat_over_padded_coif"
+		name="{=2MdVVkVL}Kettle Hat over Padded Coif"
+		mesh="vlandia_helmet_i_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.6"
+		appearance="1.9"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type3"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_cervelliere_over_laced_coif"
+		name="{=h6UXvU3B}Nasal Cervelliere over Laced Coif"
+		mesh="vlandia_helmet_o_c"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.1"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="28"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_nasal_helmet_over_padded_coif"
+		name="{=Tp7zXWGa}Nasal Helmet over Padded Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_p_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		difficulty="0"
+		appearance="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_open_padded_coif"
+		name="{=WUArer5A}Open Padded Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_y"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		difficulty="0"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="14"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth"
+				material_type="Cloth"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_padded_coif"
+		name="{=zQv3w264}Padded Half Coif"
+		subtype="head_armor"
+		mesh="vlandia_helmet_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="0.7"
+		difficulty="0"
+		appearance="1.2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="14"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="cloth"
+				material_type="Cloth"
+				beard_cover_type="type3" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_cervelliere_over_laced_coif"
+		name="{=z8d2uyY1}Segmented Cevelliere over Laced Coif"
+		mesh="vlandia_helmet_u_c"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.3"
+		appearance="1.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="24"
+				has_gender_variations="false"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate"
+				hair_cover_type="all" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_segmented_cervelliere_over_mail"
+		name="{=bdpjqoGe}Segmented Cervelliere over Mail"
+		mesh="vlandia_helmet_u_v"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.85"
+		appearance="1.45"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="26"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="type2" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_visored_helmet_over_laced_coif"
+		name="{=51EcVnzd}Visored Helmet over Laced Coif"
+		mesh="vlandia_helmet_m_c"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		appearance="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="46"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_visored_helmet_over_padded_cloth"
+		name="{=A8MJWbhf}Visored Helmet over Padded Cloth"
+		subtype="head_armor"
+		mesh="vlandia_helmet_m_y"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="3.3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="46"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate"
+				beard_cover_type="all" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandian_faceguard_helmet_a"
+		name="{=axaK9y6E}Closed Knight Helmet"
+		subtype="head_armor"
+		mesh="vlandian_faceguard_helmet_a"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.2"
+		difficulty="0"
+		appearance="1"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="45"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_vlandian_faceguard_helmet_b"
+		name="{=ArbBALwc}Knight Helmet with Bronze Faceguard"
+		subtype="head_armor"
+		mesh="vlandian_faceguard_helmet_b"
+		culture="Culture.vlandia"
+		value="1"
+		is_merchandise="false"
+		weight="2.3"
+		difficulty="0"
+		appearance="1.5"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="44"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_scale_armor_a"
+		name="{=QlvnKQbc}Highland Scale Armor over Mail Armor"
+		subtype="body_armor"
+		mesh="battanian_scale_armor_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="22.4"
+		difficulty="0"
+		appearance="3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="42"
+				leg_armor="15"
+				arm_armor="12"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battanian_scale_armor_b"
+		name="{=oJKXjRJ3}Highland Scale Armor over Cloth"
+		subtype="body_armor"
+		mesh="battanian_scale_armor_b"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="11.4"
+		difficulty="0"
+		appearance="3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="31"
+				leg_armor="6"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_a"
+		name="{=HkwJao2z}Fringed Steel Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="36"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_a_brnz"
+		name="{=HBaSQlSJ}Fringed Bronze Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_a_brnz"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.2"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_b"
+		name="{=HvjviTTW}Steel Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_b"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="2.9"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="32"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_b_brnz"
+		name="{=PyeZ22FL}Bronze Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_b_brnz"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="31"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_c"
+		name="{=1zFYpSSY}Fringed Decorated Steel Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_c"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.1"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="38"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_c_brnz"
+		name="{=KoyU5yeY}Fringed Decorated Bronze Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_c_brnz"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="37"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_c_cpr"
+		name="{=NiBDR9ld}Decorated Bronze Helmet with Cheek Guards"
+		mesh="battania_earmuff_helmet_c_cpr"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_d"
+		name="{=wQY1oqdK}Ridged Decorated Steel Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_d"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.2"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="41"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_earmuff_helmet_d_brnz"
+		name="{=RDbqA36B}Ridged Decorated Bronze Cap with Cheek Guards"
+		mesh="battania_earmuff_helmet_d_brnz"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.3"
+		difficulty="0"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="40"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_scarf_a"
+		name="{=Ur3Q4U5x}Heavy Tartan Cape"
+		mesh="battania_scarf_a"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="body_armor"
+		weight="0.55"
+		difficulty="0"
+		appearance="1.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="3"
+				arm_armor="1"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_cloak_b"
+		name="{=lVtoBMhp}Tartan Cape"
+		mesh="battania_cloak_b"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		subtype="body_armor"
+		weight="0.8"
+		difficulty="0"
+		appearance="1.5"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_battania_shoulder_strap"
+		name="{=y1YTxkmn}Shoulder Harness"
+		mesh="battania_shoulder_strap"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		appearance="1"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="4"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_aserai_civil_d"
+		name="{=SW3lkPHe}Colored Bisht"
+		mesh="aserai_civil_d"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="1.0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="5"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			Civilian="true"
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_desert_scale_shoulders"
+		name="{=sbbNL1qF}Reinforced Scale Pauldrons"
+		mesh="aserai_scale_b_shoulder"
+		culture="Culture.aserai"
+		value="1"
+		is_merchandise="false"
+		weight="4.2"
+		appearance="3"
+		Type="Cape">
+		<ItemComponent>
+			<Armor
+				body_armor="18"
+				arm_armor="8"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_khuzait_noble_helmet_with_feathers"
+		name="{=n1A47HcZ}Noble Lancer Helmet"
+		mesh="khuzait_lord_helmet_a"
+		culture="Culture.khuzait"
+		value="1"
+		is_merchandise="false"
+		subtype="head_armor"
+		weight="3.4"
+		difficulty="0"
+		appearance="4.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="48"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_chainmale_longsleeve"
+		name="{=4cHMe6H2}Decorated Hauberk"
+		subtype="body_armor"
+		mesh="sturgian_chainmale_longsleeve"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="14.5"
+		difficulty="0"
+		appearance="1.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="32"
+				leg_armor="15"
+				arm_armor="15"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_chainmale_shortsleeve"
+		name="{=RmUJJelp}Huscarls Hauberk"
+		subtype="body_armor"
+		mesh="sturgian_chainmale_shortsleeve"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="8.3"
+		difficulty="0"
+		appearance="1.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="25"
+				leg_armor="12"
+				arm_armor="10"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="chain"
+				material_type="Chainmail" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lamellar_base"
+		name="{=TeIcf3Cd}Heavy Lamellar over Mail Armor"
+		mesh="sturgian_lamellar_base"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="24"
+		appearance="3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="50"
+				leg_armor="21"
+				arm_armor="7"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lamellar_gambeson"
+		name="{=luoXhz19}Heavy Lamellar Vest"
+		subtype="body_armor"
+		mesh="sturgian_lamellar_gambeson"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="6.2"
+		difficulty="0"
+		appearance="1.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="28"
+				leg_armor="2"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lamellar_fortified"
+		name="{=D358wBWJ}Heavy Lamellar over Hauberk"
+		mesh="sturgian_lamellar_fortified"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="28"
+		appearance="3"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="50"
+				leg_armor="25"
+				arm_armor="15"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_lamellar_gambeson_heavy"
+		name="{=luoXhz19}Heavy Lamellar Vest"
+		subtype="body_armor"
+		mesh="sturgian_lamellar_gambeson_heavy"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="8.3"
+		difficulty="0"
+		appearance="1.8"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="35"
+				leg_armor="18"
+				arm_armor="2"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_light_armor_a"
+		name="{=JCdVJYnQ}Light Tunic"
+		subtype="body_armor"
+		mesh="sturgia_light_armor_a"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_light_armor_b"
+		name="{=lB4UF1GT}Long Tunic"
+		subtype="body_armor"
+		mesh="sturgia_light_armor_b"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_light_armor_c"
+		name="{=SvYpE52J}Fur Trimmed Tunic"
+		subtype="body_armor"
+		mesh="sturgia_light_armor_c"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.8"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="3"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_light_armor_d"
+		name="{=VaqBBaQu}Fur Trimmed Short Tunic"
+		subtype="body_armor"
+		mesh="sturgia_light_armor_d"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.4"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="2"
+				leg_armor="1"
+				arm_armor="1"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgia_light_armor_e"
+		name="{=oQSZ0XgP}Decorated Thick Tunic"
+		subtype="body_armor"
+		mesh="sturgia_light_armor_e"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="0.6"
+		difficulty="0"
+		appearance="0.6"
+		Type="BodyArmor">
+		<ItemComponent>
+			<Armor
+				body_armor="6"
+				leg_armor="3"
+				arm_armor="3"
+				has_gender_variations="true"
+				covers_body="true"
+				modifier_group="cloth_unarmoured"
+				material_type="Cloth" />
+		</ItemComponent>
+		<Flags
+			UseTeamColor="true"
+			Civilian="true" />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_helmet_base"
+		name="{=Nv0eZmGL}Steel Nasal Cap"
+		mesh="sturgian_helmet_base"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="2.4"
+		appearance="1.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="35"
+				has_gender_variations="false"
+				hair_cover_type="type3"
+				beard_cover_type="none"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_helmet_b_open"
+		name="{=LRbGXEw2}Plumed Decorated Mailed Nasal Helmet"
+		mesh="sturgian_helmet_b_open"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="3.2"
+		appearance="3.4"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="49"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_helmet_b_close"
+		name="{=zBRB0P5M}Closed Decorated Goggled Helmet"
+		mesh="sturgian_helmet_b_close"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="3.8"
+		appearance="2"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="54"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_helmet_open"
+		name="{=IGazuB9B}Mailed Nasal Helmet"
+		mesh="sturgian_helmet_open"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="3.15"
+		appearance="1.6"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="49"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="type2"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_sturgian_helmet_closed"
+		name="{=2iDtlgM0}Closed Warlord Helmet"
+		mesh="sturgian_helmet_closed"
+		culture="Culture.sturgia"
+		value="1"
+		is_merchandise="false"
+		weight="3.8"
+		appearance="3"
+		Type="HeadArmor">
+		<ItemComponent>
+			<Armor
+				head_armor="53"
+				has_gender_variations="false"
+				hair_cover_type="all"
+				beard_cover_type="all"
+				modifier_group="plate"
+				material_type="Plate" />
+		</ItemComponent>
+		<Flags />
+	</Item>
+	<Item
+		multiplayer_item="true"
+		id="mp_roughtied_leather_bracers"
+		name="{=e4lKZhgv}Roughtied Leather Bracers"
+		mesh="sea_raider_leather_wristband"
+		culture="Culture.battania"
+		value="1"
+		is_merchandise="false"
+		weight="0.5"
+		appearance="1"
+		Type="HandArmor">
+		<ItemComponent>
+			<Armor
+				arm_armor="3"
+				covers_hands="false"
+				modifier_group="leather"
+				material_type="Leather" />
+		</ItemComponent>
+		<Flags
+			Civilian="true" />
+	</Item>
+</Items>

--- a/IMPLEMENTATION_CHECKLIST.md
+++ b/IMPLEMENTATION_CHECKLIST.md
@@ -1,0 +1,228 @@
+# XML Model Adaptation Implementation Checklist
+
+## Immediate Action Items for 46 Remaining Failures
+
+### Priority 1: Critical Path Models (Address 80% of failures)
+
+#### PhysicsMaterials Model Fix (Estimated fix: 15 failures)
+```csharp
+// PhysMaterials model corrections
+public class PhysicsMaterial
+{
+    [XmlAttribute("id")]
+    public string Id { get; set; } = string.Empty;  // Required
+    
+    [XmlAttribute("override_material_name_for_impact_sounds")]
+    public string? OverrideMaterialNameForImpactSounds { get; set; }
+    
+    [XmlAttribute("dont_stick_missiles")]
+    public string? DontStickMissiles { get; set; }
+    
+    [XmlAttribute("attacks_can_pass_through")]
+    public string? AttacksCanPassThrough { get; set; }
+    
+    [XmlAttribute("rain_splashes_enabled")]
+    public string? RainSplashesEnabled { get; set; }
+    
+    [XmlAttribute("flammable")]
+    public string? Flammable { get; set; }
+    
+    [XmlAttribute("static_friction")]
+    public string? StaticFriction { get; set; }
+    
+    [XmlAttribute("dynamic_friction")]
+    public string? DynamicFriction { get; set; }
+    
+    [XmlAttribute("restitution")]
+    public string? Restitution { get; set; }
+    
+    [XmlAttribute("softness")]
+    public string? Softness { get; set; }
+    
+    [XmlAttribute("linear_damping")]
+    public string? LinearDamping { get; set; }
+    
+    [XmlAttribute("angular_damping")]
+    public string? AngularDamping { get; set; }
+    
+    [XmlAttribute("display_color")]
+    public string? DisplayColor { get; set; }
+    
+    // Ensure proper serialization control
+    public bool ShouldSerializeOverrideMaterialNameForImpactSounds() => !string.IsNullOrWhiteSpace(OverrideMaterialNameForImpactSounds);
+    public bool ShouldSerializeDontStickMissiles() => !string.IsNullOrWhiteSpace(DontStickMissiles);
+    public bool ShouldSerializeAttacksCanPassThrough() => !string.IsNullOrWhiteSpace(AttacksCanPassThrough);
+    public bool ShouldSerializeRainSplashesEnabled() => !string.IsNullOrWhiteSpace(RainSplashesEnabled);
+    public bool ShouldSerializeFlammable() => !string.IsNullOrWhiteSpace(Flammable);
+    public bool ShouldSerializeDisplayColor() => !string.IsNullOrWhiteSpace(DisplayColor);
+    
+    // All numeric attributes need ShouldSerialize when they have 0 default
+    public bool ShouldSerializeSoftness() => !string.IsNullOrWhiteSpace(Softness) && Softness != "0" && Softness != "0.0" && Softness != "0.000";
+    public bool ShouldSerializeStaticFriction() => !string.IsNullOrWhiteSpace(StaticFriction);
+    public bool ShouldSerializeDynamicFriction() => !string.IsNullOrWhiteSpace(DynamicFriction);
+    public bool ShouldSerializeRestitution() => !string.IsNullOrWhiteSpace(Restitution);
+    public bool ShouldSerializeLinearDamping() => !string.IsNullOrWhiteSpace(LinearDamping);
+    public bool ShouldSerializeAngularDamping() => !string.IsNullOrWhiteSpace(AngularDamping);
+}
+```
+
+#### Monsters Model Fix (Estimated fix: 20 failures)
+Fix the Monster class and MonsterFlags nested structure:
+
+```csharp
+public class Monster
+{
+    // Required attributes
+    [XmlAttribute("id")]
+    public string Id { get; set; } = string.Empty;
+    
+    // Optional attributes - all string type for format preservation
+    [XmlAttribute("base_monster")]
+    public string? BaseMonster { get; set; }
+    [XmlAttribute("action_set")]
+    public string? ActionSet { get; set; }
+    [XmlAttribute("female_action_set")]
+    public string? FemaleActionSet { get; set; }
+    [XmlAttribute("monster_usage")]
+    public string? MonsterUsage { get; set; }
+    [XmlAttribute("weight")]
+    public string? Weight { get; set; }
+    [XmlAttribute("hit_points")]
+    public string? HitPoints { get; set; }
+    [XmlAttribute("absorbed_damage_ratio")]
+    public string? AbsorbedDamageRatio { get; set; }
+    
+    // Add ShouldSerialize for all optional attributes
+    public bool ShouldSerializeBaseMonster() => !string.IsNullOrWhiteSpace(BaseMonster);
+    public bool ShouldSerializeActionSet() => !string.IsNullOrWhiteSpace(ActionSet);
+    public bool ShouldSerializeFemaleActionSet() => !string.IsNullOrWhiteSpace(FemaleActionSet);
+    public bool ShouldSerializeMonsterUsage() => !string.IsNullOrWhiteSpace(MonsterUsage);
+    public bool ShouldSerializeWeight() => !string.IsNullOrWhiteSpace(Weight);
+    public bool ShouldSerializeHitPoints() => !string.IsNullOrWhiteSpace(HitPoints);
+    public bool ShouldSerializeAbsorbedDamageRatio() => !string.IsNullOrWhiteSpace(AbsorbedDamageRatio);
+    
+    // Fix all other numeric/string attributes similarly...
+}
+
+public class MonsterCapsules
+{
+    [XmlElement("body_capsule")]
+    public MonsterCapsule? BodyCapsule { get; set; }
+    [XmlElement("crouched_body_capsule")]
+    public MonsterCapsule? CrouchedBodyCapsule { get; set; }
+    
+    public bool ShouldSerializeBodyCapsule() => BodyCapsule != null;
+    public bool ShouldSerializeCrouchedBodyCapsule() => CrouchedBodyCapsule != null;
+}
+
+public class MonsterCapsule
+{
+    [XmlAttribute("radius")]
+    public string? Radius { get; set; }
+    [XmlAttribute("pos1")]
+    public string? Pos1 { get; set; }
+    [XmlAttribute("pos2")]
+    public string? Pos2 { get; set; }
+}
+
+public class MonsterFlags
+{
+    // ALL boolean attributes as strings with ShouldSerialize methods
+    [XmlAttribute("CanAttack")]
+    public string? CanAttack { get; set; }
+    [XmlAttribute("CanDefend")]
+    public string? CanDefend { get; set; }
+    [XmlAttribute("CanKick")]
+    public string? CanKick { get; set; }
+    [XmlAttribute("CanBeCharged")]
+    public string? CanBeCharged { get; set; }
+    [XmlAttribute("CanCharge")]
+    public string? CanCharge { get; set; }
+    [XmlAttribute("CanClimbLadders")]
+    public string? CanClimbLadders { get; set; }
+    [XmlAttribute("CanSprint")]
+    public string? CanSprint { get; set; }
+    [XmlAttribute("CanCrouch")]
+    public string? CanCrouch { get; set; }
+    [XmlAttribute("CanRetreat")]
+    public string? CanRetreat { get; set; }
+    [XmlAttribute("CanRear")]
+    public string? CanRear { get; set; }
+    [XmlAttribute("CanWander")]
+    public string? CanWander { get; set; }
+    [XmlAttribute("CanBeInGroup")]
+    public string? CanBeInGroup { get; set; }
+    [XmlAttribute("MoveAsHerd")]
+    public string? MoveAsHerd { get; set; }
+    [XmlAttribute("MoveForwardOnly")]
+    public string? MoveForwardOnly { get; set; }
+    [XmlAttribute("IsHumanoid")]
+    public string? IsHumanoid { get; set; }
+    [XmlAttribute("Mountable")]
+    public string? Mountable { get; set; }
+    [XmlAttribute("CanRide")]
+    public string? CanRide { get; set; }
+    [XmlAttribute("CanWieldWeapon")]
+    public string? CanWieldWeapon { get; set; }
+    [XmlAttribute("RunsAwayWhenHit")]
+    public string? RunsAwayWhenHit { get; set; }
+    [XmlAttribute("CanGetScared")]
+    public string? CanGetScared { get; set; }
+    
+    // ShouldSerialize methods for all optional attributes
+    public bool ShouldSerializeCanAttack() => !string.IsNullOrWhiteSpace(CanAttack);
+    public bool ShouldSerializeCanDefend() => !string.IsNullOrWhiteSpace(CanDefend);
+    public bool ShouldSerializeCanKick() => !string.IsNullOrWhiteSpace(CanKick);
+    public bool ShouldSerializeCanBeCharged() => !string.IsNullOrWhiteSpace(CanBeCharged);
+    public bool ShouldSerializeCanCharge() => !string.IsNullOrWhiteSpace(CanCharge);
+    public bool ShouldSerializeCanClimbLadders() => !string.IsNullOrWhiteSpace(CanClimbLadders);
+    public bool ShouldSerializeCanSprint() => !string.IsNullOrWhiteSpace(CanSprint);
+    public bool ShouldSerializeCanCrouch() => !string.IsNullOrWhiteSpace(CanCrouch);
+    public bool ShouldSerializeCanRetreat() => !string.IsNullOrWhiteSpace(CanRetreat);
+    public bool ShouldSerializeCanRear() => !string.IsNullOrWhiteSpace(CanRear);
+    public bool ShouldSerializeCanWander() => !string.IsNullOrWhiteSpace(CanWander);
+    public bool ShouldSerializeCanBeInGroup() => !string.IsNullOrWhiteSpace(CanBeInGroup);
+    public bool ShouldSerializeMoveAsHerd() => !string.IsNullOrWhiteSpace(MoveAsHerd);
+    public bool ShouldSerializeMoveForwardOnly() => !string.IsNullOrWhiteSpace(MoveForwardOnly);
+    public bool ShouldSerializeIsHumanoid() => !string.IsNullOrWhiteSpace(IsHumanoid);
+    public bool ShouldSerializeMountable() => !string.IsNullOrWhiteSpace(Mountable);
+    public bool ShouldSerializeCanRide() => !string.IsNullOrWhiteSpace(CanRide);
+    public bool ShouldSerializeCanWieldWeapon() => !string.IsNullOrWhiteSpace(CanWieldWeapon);
+    public bool ShouldSerializeRunsAwayWhenHit() => !string.IsNullOrWhiteSpace(RunsAwayWhenHit);
+    public bool ShouldSerializeCanGetScared() => !string.IsNullOrWhiteSpace(CanGetScared);
+}
+```
+
+### Priority 2: Remaining Models (Address final 11 failures)
+
+#### Quick Fixes for Remaining Models
+1. **ProjectConfiguration.cs** - Fix optional string attributes
+2. **AttributesDataModel.cs** - Ensure ShouldSerialize methods exist for optional attributes
+3. **ActionTypesModel.cs** - Ensure optional attributes have proper string handling
+4. **ModuleXmlModel.cs** - Review and fix similar patterns
+
+### Testing Strategy
+
+#### Immediate Verification Steps
+1. **Run Single Test**: Pick one failing test (e.g., PhysicsMaterialsXmlTests) and fix only that model
+2. **Verify Round-trip**: Ensure the fixed model passes structural equality tests
+3. **Apply Pattern**: Use the successful pattern to fix all similar models
+
+#### Pattern for Testing After Fix
+```bash
+# Test individual components
+dotnet test BannerlordModEditor.Common.Tests/PhysicsMaterialsXmlTests.cs
+dotnet test BannerlordModEditor.Common.Tests/MonstersXmlTests.cs
+
+# Run targeted tests to verify fixes
+dotnet test --filter Category=XmlSerialization
+```
+
+### Implementation Order
+
+1. **Start with PhysicsMaterials** (simplest fix, high impact)
+2. **Fix Monsters** (complex but pattern from PhysicsMaterials)
+3. **Apply pattern to remaining models**
+4. **Verify all 46 tests pass**
+
+This checklist provides the immediate path to resolve all 46 remaining XML adaptation failures through systematic application of string-based properties and proper ShouldSerialize methods.

--- a/XML_Adaptation_Specifications.md
+++ b/XML_Adaptation_Specifications.md
@@ -1,0 +1,378 @@
+# Bannerlord Mod Editor - XML Model Adaptation Specifications
+
+## 1. Current State Analysis
+
+### Progress Summary
+- Successfully reduced test failures from 273 to 46 failures through namespace serialization fixes
+- Main remaining issues are model-specific adaptation problems
+- Boolean normalization issues have been addressed
+- Focus is now on field/attribute mapping precision
+
+### Major Failure Categories
+
+#### 1.1 Attribute Value Handling Issues
+- **Boolean Value Normalization**: XML attributes with boolean values show case sensitivity issues (true/True, false/False)
+- **Numeric Value Formatting**: Floating-point numbers may differ in precision or format between serialization rounds
+- **Whitespace Handling**: Leading/trailing whitespace in attribute values affecting structural equality
+
+#### 1.2 Missing or Extra Attributes
+- **Optional Attribute Omission**: Attributes that should be omitted when empty are serialized with empty values
+- **Required Attribute Absence**: Attributes that are required are not properly mapped or missing
+- **Computed/Generated Attributes**: Attributes added by the game engine during runtime are being serialized inappropriately
+
+#### 1.3 Nested Element Structure Mismatches
+- **Element Ordering**: XML elements require specific ordering that isn't preserved in C# object serialization
+- **Empty Element Serialization**: Empty elements that should be self-closing or omitted entirely
+- **Collection Handling**: Repeated elements from collections not matching source XML structure
+
+#### 1.4 Field Presence/Absence Rules
+- **Strict Field Existence**: XML elements and attributes must exactly match - present attributes must be present, absent attributes must be absent
+- **Null vs Empty vs Missing**: Different handling required for null values, empty strings, and completely missing fields
+- **Conditional Field Serialization**: Fields that should only be serialized under certain conditions
+
+## 2. Requirements Documentation
+
+### 2.1 Bannerlord Game XML Format Requirements
+
+#### 2.1.1 File Structure Constraints
+- XML files must preserve exact element and attribute names as used by the Bannerlord game engine
+- File encoding must be UTF-8 with appropriate XML declaration
+- No additional namespaces or schema declarations should be added
+- Self-closing tags should be properly formatted and consistent
+
+#### 2.1.2 Element and Attribute Requirements
+- **Attribute Names**: Must exactly match game XML files (case-sensitive)
+- **Attribute Values**: Must preserve exact string representation from source files
+- **Element Nesting**: Must preserve parent-child relationships exactly as in source files
+- **Element Ordering**: Certain XML files require specific element ordering (game engine sensitive)
+
+#### 2.1.3 Value Representation Requirements
+- **Boolean Values**: Must preserve exact case and format as seen in original files
+- **Numeric Values**: Must preserve exact precision and formatting (no rounding)
+- **String Values**: Must preserve all whitespace and special character encoding
+- **Empty Values**: Must distinguish between empty strings and missing attributes/elements
+
+### 2.2 Critical Behavioral Requirements
+
+#### 2.2.1 Strict File Format Preservation
+```
+MUST NOT modify field presence/absence in XML files
+MUST preserve all original whitespace and formatting where possible
+MUST maintain exact element and attribute ordering where specified
+MUST preserve original boolean/numeric formatting and case
+```
+
+#### 2.2.2 Round-trip Serialization Consistency
+```
+Deserialize(Serialize(original_xml)) == original_xml (structurally equivalent)
+No additional elements or attributes should be added
+No existing elements or attributes should be removed
+All values must be preserved exactly as originally parsed
+```
+
+#### 2.2.3 Field Handling Precision
+```
+Null values in C# objects must NOT create XML attributes/elements
+Empty string values in C# objects must NOT create XML attributes/elements
+Missing C# properties must NOT create XML attributes/elements
+Only populated fields with non-null, non-empty values should be serialized
+```
+
+## 3. Technical Specifications
+
+### 3.1 XML-C# Model Mapping Rules
+
+#### 3.1.1 Attribute Mapping
+```xml
+<!-- XML Source -->
+<action name="act_jump" type="actt_jump_start" usage_direction="ud_defend_up" />
+```
+
+```csharp
+// C# Model
+public class ActionType
+{
+    [XmlAttribute("name")]
+    public string Name { get; set; } = string.Empty;
+    
+    [XmlAttribute("type")]
+    public string? Type { get; set; }
+    
+    [XmlAttribute("usage_direction")]
+    public string? UsageDirection { get; set; }
+    
+    // ShouldSerialize methods control attribute serialization
+    public bool ShouldSerializeType() => !string.IsNullOrEmpty(Type);
+    public bool ShouldSerializeUsageDirection() => !string.IsNullOrEmpty(UsageDirection);
+}
+```
+
+#### 3.1.2 Element Mapping
+```xml
+<!-- XML Source -->
+<Monster id="human" weight="80">
+    <Capsules>
+        <body_capsule radius="0.4" pos1="0, 1.2, 1.5" pos2="0, -0.37, 1.5" />
+    </Capsules>
+    <Flags CanAttack="true" CanDefend="true" />
+</Monster>
+```
+
+```csharp
+// C# Model
+public class Monster
+{
+    [XmlAttribute("id")]
+    public string Id { get; set; } = string.Empty;
+    
+    [XmlAttribute("weight")]
+    public string? Weight { get; set; }
+    
+    [XmlElement("Capsules")]
+    public MonsterCapsules? Capsules { get; set; }
+    
+    [XmlElement("Flags")]
+    public MonsterFlags? Flags { get; set; }
+    
+    public bool ShouldSerializeWeight() => !string.IsNullOrWhiteSpace(Weight);
+    public bool ShouldSerializeCapsules() => Capsules != null;
+    public bool ShouldSerializeFlags() => Flags != null;
+}
+```
+
+### 3.2 Field Handling Specifications
+
+#### 3.2.1 Null Value Handling
+- **C# Property Value**: `null`
+- **XML Serialization Result**: Attribute/Element is NOT created
+- **ShouldSerialize Method**: Must return `false`
+
+#### 3.2.2 Empty String Handling
+- **C# Property Value**: `""` (empty string)
+- **XML Serialization Result**: Attribute/Element is NOT created
+- **ShouldSerialize Method**: Must return `false`
+
+#### 3.2.3 Whitespace-only String Handling
+- **C# Property Value**: `"   "` (whitespace-only)
+- **XML Serialization Result**: Attribute/Element is NOT created
+- **ShouldSerialize Method**: Must return `false` (using `string.IsNullOrWhiteSpace()`)
+
+#### 3.2.4 Valid Value Handling
+- **C# Property Value**: `"actual_value"`
+- **XML Serialization Result**: Attribute/Element IS created with exact value
+- **ShouldSerialize Method**: Must return `true`
+
+### 3.3 Special Value Type Handling
+
+#### 3.3.1 Boolean Values
+```
+XML Input:  "true"  → C# Property: "true"  → XML Output: "true"
+XML Input:  "True"  → C# Property: "True"  → XML Output: "True"
+XML Input:  "false" → C# Property: "false" → XML Output: "false"
+XML Input:  "False" → C# Property: "False" → XML Output: "False"
+```
+
+#### 3.3.2 Numeric Values
+```
+XML Input:  "1.0"    → C# Property: "1.0"    → XML Output: "1.0"
+XML Input:  "1.0000" → C# Property: "1.0000" → XML Output: "1.0000"
+XML Input:  "80"     → C# Property: "80"     → XML Output: "80"
+```
+
+#### 3.3.3 Coordinate/Tuple Values
+```
+XML Input:  "0.13, 0.1, 0.0" → C# Property: "0.13, 0.1, 0.0" → XML Output: "0.13, 0.1, 0.0"
+XML Input:  "0, 1.2, 1.5"    → C# Property: "0, 1.2, 1.5"    → XML Output: "0, 1.2, 1.5"
+```
+
+## 4. Acceptance Criteria
+
+### 4.1 Round-trip Testing Requirements
+
+#### 4.1.1 Structural Equality
+```csharp
+// Test Pattern
+string originalXml = File.ReadAllText(testFile);
+var model = XmlTestUtils.Deserialize<ModelType>(originalXml);
+string serializedXml = XmlTestUtils.Serialize(model);
+Assert.True(XmlTestUtils.AreStructurallyEqual(originalXml, serializedXml));
+```
+
+#### 4.1.2 Node and Attribute Count Matching
+```csharp
+var (nodeCountA, attrCountA) = XmlTestUtils.CountNodesAndAttributes(originalXml);
+var (nodeCountB, attrCountB) = XmlTestUtils.CountNodesAndAttributes(serializedXml);
+Assert.Equal(nodeCountA, nodeCountB);
+Assert.Equal(attrCountA, attrCountB);
+```
+
+#### 4.1.3 Value Preservation
+- All attribute values must be identical (byte-for-byte matching)
+- All element content must be preserved
+- Whitespace within values must be maintained exactly
+- Case sensitivity must be preserved for all values
+
+### 4.2 Model Compliance Requirements
+
+#### 4.2.1 Attribute Serialization Control
+- Every optional attribute must have corresponding `ShouldSerialize{PropertyName}()` method
+- `ShouldSerialize` methods must return `false` for null/empty/whitespace-only values
+- Required attributes should NOT have `ShouldSerialize` methods
+
+#### 4.2.2 Element Serialization Control
+- Every optional complex element must have corresponding `ShouldSerialize{PropertyName}()` method
+- Collections should be handled with appropriate null/empty checking logic
+- Nested elements must preserve their structure through proper `XmlElement` attributes
+
+#### 4.2.3 Type Safety and Validation
+- All XML attributes should map to appropriate C# property types
+- String properties should be used for values that require exact preservation
+- Validation attributes should be applied where applicable
+- Documentation should be provided for complex mappings
+
+## 5. XML Adaptation Rules
+
+### 5.1 Field Presence Rules
+
+#### Rule 1: Required Fields
+```
+REQUIRED: Fields that must always be present in both XML and C# model
+- XML: Attribute/element must exist with a non-empty value
+- C# Model: Property must be non-nullable and assigned a default value
+- ShouldSerialize: Not needed (always serialized)
+```
+
+#### Rule 2: Optional Fields
+```
+OPTIONAL: Fields that may or may not be present in XML
+- XML: Attribute/element may be absent or present with value
+- C# Model: Property should be nullable or have appropriate default
+- ShouldSerialize: Required to control serialization behavior
+```
+
+#### Rule 3: Conditional Fields
+```
+CONDITIONAL: Fields that are present only under certain conditions
+- XML: Attribute/element presence depends on other field values
+- C# Model: Complex logic in ShouldSerialize method
+- ShouldSerialize: Complex conditions checking related properties
+```
+
+### 5.2 Value Handling Rules
+
+#### Rule 1: Exact Value Preservation
+```
+MUST preserve exact string representation from XML source
+- NO conversion to different data types during round-trip
+- NO formatting or normalization of values
+- NO trimming or modification of whitespace
+```
+
+#### Rule 2: Boolean Value Handling
+```
+Preserve exact boolean string representation from source
+- "true" stays "true", not converted to "True" or boolean true
+- "false" stays "false", not converted to "False" or boolean false
+- Case-sensitive matching to original file format
+```
+
+#### Rule 3: Numeric Value Handling
+```
+Preserve exact numeric string representation from source
+- "1.0" stays "1.0", not converted to "1" or 1.0
+- "1.0000" stays "1.0000", not rounded or simplified
+- Scientific notation must be preserved exactly
+```
+
+### 5.3 Serialization Control Pattern
+
+#### Pattern 1: Simple Optional String Attribute
+```csharp
+[XmlAttribute("description")]
+public string? Description { get; set; }
+
+public bool ShouldSerializeDescription() => !string.IsNullOrWhiteSpace(Description);
+```
+
+#### Pattern 2: Optional Complex Element
+```csharp
+[XmlElement("Documentation")]
+public DocumentationElement? Documentation { get; set; }
+
+public bool ShouldSerializeDocumentation() => Documentation != null;
+```
+
+#### Pattern 3: Optional Collection Element
+```csharp
+[XmlArray("Items")]
+[XmlArrayItem("Item")]
+public List<Item>? Items { get; set; }
+
+public bool ShouldSerializeItems() => Items != null && Items.Count > 0;
+```
+
+#### Pattern 4: Required Field (No ShouldSerialize)
+```csharp
+[XmlAttribute("id")]
+public string Id { get; set; } = string.Empty;
+// No ShouldSerialize method - always required
+```
+
+## 6. Implementation Guidelines
+
+### 6.1 Model Design Principles
+
+#### 6.1.1 Use String Properties for Exact Preservation
+```csharp
+// CORRECT - preserves exact format
+[XmlAttribute("weight")]
+public string? Weight { get; set; }
+
+// INCORRECT - may cause format changes
+[XmlAttribute("weight")]
+public float Weight { get; set; }
+```
+
+#### 6.1.2 Implement Proper ShouldSerialize Methods
+```csharp
+// For optional string attributes
+public bool ShouldSerializePropertyName() => !string.IsNullOrWhiteSpace(PropertyName);
+
+// For optional complex objects
+public bool ShouldSerializeObjectName() => ObjectName != null;
+
+// For optional collections
+public bool ShouldSerializeCollectionName() => CollectionName != null && CollectionName.Count > 0;
+```
+
+#### 6.1.3 Use Appropriate XML Attributes
+```csharp
+// For single elements
+[XmlElement("Capsules")]
+
+// For collections (arrays)
+[XmlArray("Items")]
+[XmlArrayItem("Item")]
+
+// For attributes
+[XmlAttribute("id")]
+
+// For root elements
+[XmlRoot("Monsters")]
+```
+
+### 6.2 Testing Requirements
+
+#### 6.2.1 Comprehensive Test Coverage
+- Every XML file must have corresponding round-trip test
+- Large XML files should have subset testing capability
+- Edge cases like empty elements, self-closing tags must be tested
+- Files with different formatting styles must be supported
+
+#### 6.2.2 Validation Testing
+- Structural equality must be verified for all test cases
+- Node and attribute counts must match before and after serialization
+- Value preservation must be exact (byte-for-byte when appropriate)
+- Error handling for malformed XML should be considered
+
+This specification document provides the comprehensive framework for addressing the remaining 46 XML adaptation failures while maintaining strict compatibility with Bannerlord's XML format requirements.

--- a/XML_Adaptation_Technical_Analysis.md
+++ b/XML_Adaptation_Technical_Analysis.md
@@ -1,0 +1,434 @@
+# Bannerlord Mod Editor - Technical Analysis and Implementation Guide
+
+## 1. Critical Issue Analysis
+
+### 1.1 Physics Materials XML Structure Analysis
+
+From examining `physics_materials.xml` and the corresponding model `PhysicsMaterials.cs`, we've identified several critical issues:
+
+#### Issue 1: Boolean Attribute Mismatch
+**Problem**: The XML contains boolean values as strings, but the C# model uses boolean types
+```xml
+<!-- XML Structure -->
+<physics_material id="pot" dont_stick_missiles="true" attacks_can_pass_through="false" />
+<physics_material id="wood" rain_splashes_enabled="true" flammable="true" />
+```
+
+```csharp
+// Current Model Problem
+public class PhysicsMaterial
+{
+    [XmlAttribute("dont_stick_missiles")]
+    [DefaultValue(false)]
+    public bool DontStickMissiles { get; set; }  // Serializes as: dont_stick_missiles="true"
+    
+    [XmlAttribute("attacks_can_pass_through")]
+    public string? AttacksCanPassThrough { get; set; }  // Correct: preserves string format
+}
+```
+
+**Root Cause**: When `bool` properties are serialized, the output is correct, but the comparison logic may fail due to type conversion differences.
+
+#### Issue 2: Missing ShouldSerialize Methods
+**Problem**: Optional string attributes lack proper serialization control
+```csharp
+// Current Model
+[XmlAttribute("override_material_name_for_impact_sounds")]
+public string? OverrideMaterialNameForImpactSounds { get; set; }  // No ShouldSerialize method
+
+// Should be:
+[XmlAttribute("override_material_name_for_impact_sounds")]
+public string? OverrideMaterialNameForImpactSounds { get; set; }
+
+public bool ShouldSerializeOverrideMaterialNameForImpactSounds() 
+    => !string.IsNullOrWhiteSpace(OverrideMaterialNameForImpactSounds);
+```
+
+#### Issue 3: Numeric Precision and Formatting
+**Problem**: Float values may lose precision or format during round-trip
+```xml
+<!-- Original XML -->
+<physics_material static_friction="0.800" dynamic_friction="0.400" />
+
+<!-- After serialization, might become: -->
+<physics_material static_friction="0.8" dynamic_friction="0.4" />
+```
+
+### 1.2 Monsters XML Structure Analysis
+
+#### Issue 1: Complex Nested Structure with Optional Elements
+```xml
+<!-- XML Structure -->
+<Monster id="human" weight="80">
+    <Capsules>
+        <body_capsule radius="0.4" pos1="0, 1.2, 1.5" pos2="0, -0.37, 1.5" />
+    </Capsules>
+    <Flags Mountable="true" CanRear="true" />
+</Monster>
+```
+
+```csharp
+// Current Model - Missing proper serialization control
+public class Monster
+{
+    [XmlElement("Capsules")]
+    public MonsterCapsules? Capsules { get; set; }  // No ShouldSerialize method
+    
+    [XmlElement("Flags")]
+    public MonsterFlags? Flags { get; set; }  // No ShouldSerialize method
+}
+```
+
+#### Issue 2: Boolean Attributes in Nested Elements
+```xml
+<!-- Nested boolean attributes -->
+<Flags Mountable="true" CanRear="true" RunsAwayWhenHit="true" />
+```
+
+```csharp
+// Current Model - Inconsistent boolean handling
+public class MonsterFlags
+{
+    [XmlAttribute("Mountable")]
+    public string? Mountable { get; set; }  // Correct: string preservation
+    
+    [XmlAttribute("CanAttack")]
+    public string? CanAttack { get; set; }  // Correct: string preservation
+}
+```
+
+## 2. Technical Implementation Strategy
+
+### 2.1 Phase 1: Fix Boolean Attribute Handling
+
+#### Strategy 1: Convert All Boolean Attributes to Strings
+```csharp
+// BEFORE (problematic)
+[XmlAttribute("dont_stick_missiles")]
+[DefaultValue(false)]
+public bool DontStickMissiles { get; set; }
+
+// AFTER (correct)
+[XmlAttribute("dont_stick_missiles")]
+public string? DontStickMissiles { get; set; }  // Preserves exact string format
+
+public bool ShouldSerializeDontStickMissiles() 
+    => !string.IsNullOrWhiteSpace(DontStickMissiles);
+```
+
+#### Strategy 2: Implement Proper ShouldSerialize Methods
+```csharp
+public class PhysicsMaterial
+{
+    [XmlAttribute("id")]
+    public string Id { get; set; } = string.Empty;  // Required - no ShouldSerialize
+    
+    [XmlAttribute("override_material_name_for_impact_sounds")]
+    public string? OverrideMaterialNameForImpactSounds { get; set; }
+    
+    [XmlAttribute("dont_stick_missiles")]
+    public string? DontStickMissiles { get; set; }
+    
+    [XmlAttribute("attacks_can_pass_through")]
+    public string? AttacksCanPassThrough { get; set; }
+    
+    [XmlAttribute("rain_splashes_enabled")]
+    public string? RainSplashesEnabled { get; set; }
+    
+    [XmlAttribute("flammable")]
+    public string? Flammable { get; set; }
+    
+    [XmlAttribute("display_color")]
+    public string? DisplayColor { get; set; }
+    
+    // ShouldSerialize methods for optional attributes
+    public bool ShouldSerializeOverrideMaterialNameForImpactSounds() 
+        => !string.IsNullOrWhiteSpace(OverrideMaterialNameForImpactSounds);
+    
+    public bool ShouldSerializeDontStickMissiles() 
+        => !string.IsNullOrWhiteSpace(DontStickMissiles);
+    
+    public bool ShouldSerializeAttacksCanPassThrough() 
+        => !string.IsNullOrWhiteSpace(AttacksCanPassThrough);
+    
+    public bool ShouldSerializeRainSplashesEnabled() 
+        => !string.IsNullOrWhiteSpace(RainSplashesEnabled);
+    
+    public bool ShouldSerializeFlammable() 
+        => !string.IsNullOrWhiteSpace(Flammable);
+    
+    public bool ShouldSerializeDisplayColor() 
+        => !string.IsNullOrWhiteSpace(DisplayColor);
+}
+```
+
+### 2.2 Phase 2: Fix Complex Element Structure Handling
+
+#### Strategy 1: Implement Proper ShouldSerialize for Complex Elements
+```csharp
+public class Monster
+{
+    [XmlAttribute("id")]
+    public string Id { get; set; } = string.Empty;  // Required
+    
+    [XmlAttribute("weight")]
+    public string? Weight { get; set; }
+    
+    [XmlElement("Capsules")]
+    public MonsterCapsules? Capsules { get; set; }
+    
+    [XmlElement("Flags")]
+    public MonsterFlags? Flags { get; set; }
+    
+    public bool ShouldSerializeWeight() 
+        => !string.IsNullOrWhiteSpace(Weight);
+    
+    public bool ShouldSerializeCapsules() 
+        => Capsules != null;
+    
+    public bool ShouldSerializeFlags() 
+        => Flags != null;
+}
+```
+
+#### Strategy 2: Handle Nested Boolean Attributes Correctly
+```csharp
+public class MonsterFlags
+{
+    [XmlAttribute("CanAttack")]
+    public string? CanAttack { get; set; }
+    
+    [XmlAttribute("CanDefend")]
+    public string? CanDefend { get; set; }
+    
+    [XmlAttribute("CanKick")]
+    public string? CanKick { get; set; }
+    
+    [XmlAttribute("CanBeCharged")]
+    public string? CanBeCharged { get; set; }
+    
+    [XmlAttribute("CanCharge")]
+    public string? CanCharge { get; set; }
+    
+    [XmlAttribute("CanClimbLadders")]
+    public string? CanClimbLadders { get; set; }
+    
+    [XmlAttribute("CanSprint")]
+    public string? CanSprint { get; set; }
+    
+    [XmlAttribute("CanCrouch")]
+    public string? CanCrouch { get; set; }
+    
+    [XmlAttribute("CanRetreat")]
+    public string? CanRetreat { get; set; }
+    
+    [XmlAttribute("CanRear")]
+    public string? CanRear { get; set; }
+    
+    [XmlAttribute("CanWander")]
+    public string? CanWander { get; set; }
+    
+    [XmlAttribute("CanBeInGroup")]
+    public string? CanBeInGroup { get; set; }
+    
+    [XmlAttribute("MoveAsHerd")]
+    public string? MoveAsHerd { get; set; }
+    
+    [XmlAttribute("MoveForwardOnly")]
+    public string? MoveForwardOnly { get; set; }
+    
+    [XmlAttribute("IsHumanoid")]
+    public string? IsHumanoid { get; set; }
+    
+    [XmlAttribute("Mountable")]
+    public string? Mountable { get; set; }
+    
+    [XmlAttribute("CanRide")]
+    public string? CanRide { get; set; }
+    
+    [XmlAttribute("CanWieldWeapon")]
+    public string? CanWieldWeapon { get; set; }
+    
+    [XmlAttribute("RunsAwayWhenHit")]
+    public string? RunsAwayWhenHit { get; set; }
+    
+    [XmlAttribute("CanGetScared")]
+    public string? CanGetScared { get; set; }
+    
+    // ShouldSerialize methods for all optional attributes
+    public bool ShouldSerializeCanAttack() 
+        => !string.IsNullOrWhiteSpace(CanAttack);
+    
+    public bool ShouldSerializeCanDefend() 
+        => !string.IsNullOrWhiteSpace(CanDefend);
+    
+    // ... similar methods for all other attributes
+}
+```
+
+### 2.3 Phase 3: Numeric Precision and Formatting
+
+#### Strategy 1: Use String Properties for Numeric Values
+```csharp
+// BEFORE (problematic - may lose precision/formatting)
+[XmlAttribute("static_friction")]
+public float StaticFriction { get; set; }
+
+// AFTER (correct - preserves exact format)
+[XmlAttribute("static_friction")]
+public string? StaticFriction { get; set; }
+
+public bool ShouldSerializeStaticFriction() 
+    => !string.IsNullOrWhiteSpace(StaticFriction);
+```
+
+#### Strategy 2: Implement Validation for Numeric Strings
+```csharp
+public class PhysicsMaterial
+{
+    [XmlAttribute("static_friction")]
+    public string? StaticFriction { get; set; }
+    
+    public bool ShouldSerializeStaticFriction() 
+        => !string.IsNullOrWhiteSpace(StaticFriction);
+    
+    public float? GetStaticFrictionValue()
+    {
+        if (float.TryParse(StaticFriction, out var value))
+            return value;
+        return null;
+    }
+    
+    public void SetStaticFrictionValue(float? value)
+    {
+        StaticFriction = value?.ToString("0.000");  // Preserve formatting
+    }
+}
+```
+
+## 3. Implementation Checklist
+
+### 3.1 PhysicsMaterials.cs Fixes Required
+
+#### Boolean Attributes to Convert to Strings
+- [ ] `DontStickMissiles` - Convert `bool` to `string?`
+- [ ] `RainSplashesEnabled` - Convert `bool` to `string?`
+- [ ] `Flammable` - Convert `bool` to `string?`
+
+#### ShouldSerialize Methods to Add
+- [ ] `ShouldSerializeOverrideMaterialNameForImpactSounds()`
+- [ ] `ShouldSerializeDontStickMissiles()`
+- [ ] `ShouldSerializeAttacksCanPassThrough()`
+- [ ] `ShouldSerializeRainSplashesEnabled()`
+- [ ] `ShouldSerializeFlammable()`
+- [ ] `ShouldSerializeDisplayColor()`
+
+#### Numeric Attributes to Convert to Strings
+- [ ] `StaticFriction` - Convert `float` to `string?`
+- [ ] `DynamicFriction` - Convert `float` to `string?`
+- [ ] `Restitution` - Convert `float` to `string?`
+- [ ] `Softness` - Convert `float` to `string?`
+- [ ] `LinearDamping` - Convert `float` to `string?`
+- [ ] `AngularDamping` - Convert `float` to `string?`
+
+### 3.2 Monsters.cs Fixes Required
+
+#### ShouldSerialize Methods to Add
+- [ ] `ShouldSerializeWeight()` for Weight attribute
+- [ ] `ShouldSerializeCapsules()` for Capsules element
+- [ ] `ShouldSerializeFlags()` for Flags element
+- [ ] All MonsterFlags ShouldSerialize methods (20+ methods)
+
+#### String Property Conversions
+- [ ] Review all numeric attributes for string conversion
+- [ ] Review all boolean attributes for consistent string handling
+
+### 3.3 General Model Updates Required
+
+#### Models Needing Review (based on 46 failures)
+- [ ] `PhysicsMaterials.cs` - Boolean and numeric attribute handling
+- [ ] `Monsters.cs` - Complex nested structure and boolean handling
+- [ ] `AttributesDataModel.cs` - Optional attribute serialization
+- [ ] `ActionTypesModel.cs` - Optional attribute serialization
+- [ ] `ProjectConfiguration.cs` - Optional element handling
+- [ ] All other models with failing tests
+
+## 4. Testing and Validation Strategy
+
+### 4.1 Unit Test Updates Required
+
+#### PhysicsMaterials Test Updates
+```csharp
+[Fact]
+public void PhysicsMaterials_RoundTrip_StructuralEquality()
+{
+    var xml = File.ReadAllText(TestDataPath);
+    var model = XmlTestUtils.Deserialize<PhysicsMaterials>(xml);
+    var serialized = XmlTestUtils.Serialize(model);
+    
+    // Test structural equality
+    Assert.True(XmlTestUtils.AreStructurallyEqual(xml, serialized));
+    
+    // Test specific attribute preservation
+    var originalMaterial = model.PhysicsMaterialList.FirstOrDefault(m => m.Id == "pot");
+    Assert.NotNull(originalMaterial);
+    Assert.Equal("true", originalMaterial.DontStickMissiles);
+    Assert.Equal("false", originalMaterial.AttacksCanPassThrough);
+}
+```
+
+#### Monsters Test Updates
+```csharp
+[Fact]
+public void Monsters_RoundTrip_StructuralEquality()
+{
+    var xml = File.ReadAllText(TestDataPath);
+    var model = XmlTestUtils.Deserialize<Monsters>(xml);
+    var serialized = XmlTestUtils.Serialize(model);
+    
+    // Test structural equality
+    Assert.True(XmlTestUtils.AreStructurallyEqual(xml, serialized));
+    
+    // Test complex nested structure preservation
+    var humanMonster = model.MonsterList.FirstOrDefault(m => m.Id == "human");
+    Assert.NotNull(humanMonster);
+    Assert.NotNull(humanMonster.Capsules);
+    Assert.NotNull(humanMonster.Flags);
+    
+    // Test boolean attribute preservation in nested elements
+    Assert.Equal("true", humanMonster.Flags.CanAttack);
+    Assert.Equal("true", humanMonster.Flags.CanDefend);
+}
+```
+
+### 4.2 Integration Testing Strategy
+
+#### Test All Failing Models
+- [ ] Run all 46 failing tests to confirm fixes
+- [ ] Verify round-trip serialization preserves exact structure
+- [ ] Verify all optional attributes are handled correctly
+- [ ] Verify numeric precision and formatting is preserved
+
+#### Performance Testing
+- [ ] Test large XML files for performance impact
+- [ ] Verify memory usage is acceptable
+- [ ] Ensure serialization speed meets requirements
+
+## 5. Rollout Plan
+
+### Phase 1: Core Model Fixes (High Priority)
+1. Fix PhysicsMaterials.cs (highest failure rate)
+2. Fix Monsters.cs (complex nested structure)
+3. Fix AttributesDataModel.cs (simple structure, high visibility)
+
+### Phase 2: Additional Model Fixes (Medium Priority)
+1. Fix remaining models with similar patterns
+2. Update unit tests to reflect new serialization behavior
+3. Add integration tests for edge cases
+
+### Phase 3: Validation and Optimization (Low Priority)
+1. Performance testing and optimization
+2. Documentation updates
+3. Code review and refactoring
+
+This technical analysis provides the detailed implementation strategy needed to address the remaining 46 XML adaptation failures while maintaining strict compliance with Bannerlord's XML format requirements.

--- a/fix_xml_serialization.sh
+++ b/fix_xml_serialization.sh
@@ -1,0 +1,27 @@
+#\!/bin/bash
+
+# 脚本用于修复XML序列化中缺少命名空间的问题
+# 查找所有需要修复的文件并应用修复
+
+echo "开始修复XML序列化中的命名空间问题..."
+
+# 创建临时文件来存储需要处理的文件列表
+grep -r "serializer\.Serialize([^,]+,[^,]+);" BannerlordModEditor.Common.Tests/ --include="*.cs" > files_to_fix.txt
+
+echo "找到需要修复的文件:"
+cat files_to_fix.txt
+
+# 逐个处理每个文件
+while IFS= read -r line; do
+    if [ -n "$line" ]; then
+        # 提取文件路径
+        file_path=$(echo "$line" | cut -d: -f1)
+        echo "处理文件: $file_path"
+        
+        # 应用修复
+        sed -i 's/\(serializer\.Serialize([^,]+,[^,]+)\);/\1\n                var ns = new XmlSerializerNamespaces();\n                ns.Add("", "");\n                serializer.Serialize(writer, model, ns);/g' "$file_path"
+    fi
+done < files_to_fix.txt
+
+echo "修复完成\!"
+rm -f files_to_fix.txt


### PR DESCRIPTION
此PR解决了XML序列化中的命名空间问题，成功修复了大部分测试失败。

- 修复了XmlTestUtils中的命名空间处理，添加了XmlSerializerNamespaces以避免额外命名空间声明
- 所有XML round-trip测试现在能正确处理命名空间
- 减少了测试失败从273个到46个，剩余的失败是模型特定的适配问题
- 添加了详细的XML适配规范和实施清单文档，为解决剩余问题提供指导

接下来将专注于解决剩余的46个模型适配失败问题。