### PR TITLE
修复GitHub Actions发布release失败问题并添加release notes支持

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -132,6 +132,7 @@ jobs:
       env:
         BUILD_NUMBER: ${{github.run_number}}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: pwsh
       run: |
         $Version = Get-Date -Format "yyyy.M.$env:BUILD_NUMBER"
@@ -185,7 +186,6 @@ jobs:
           Write-Host "Release uploaded successfully"
           
           # 添加 release notes
-          gh release edit $tagName --notes-file releasenotes.md
           try {
             gh release edit $tagName --notes-file releasenotes.md --repo $env:GITHUB_REPOSITORY
             Write-Host "Release notes updated successfully"

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -183,6 +183,10 @@ jobs:
         try {
           vpk upload github -o Releases --repoUrl https://github.com/BannerlordModer/BannerlordModEditor --publish --channel nightly-win-x64 --releaseName "BannerlordModEditor v$Version" --tag $tagName --token $env:GITHUB_TOKEN
           Write-Host "Release uploaded successfully"
+          
+          # 添加 release notes
+          gh release edit $tagName --notes-file releasenotes.md
+          Write-Host "Release notes updated successfully"
         } catch {
           Write-Host "Release upload failed with error: $_"
           exit 1

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -181,7 +181,7 @@ jobs:
         
         # 上传到 GitHub Releases
         try {
-          vpk upload github -o Releases --repoUrl https://github.com/BannerlordModer/BannerlordModEditor --publish --channel nightly-win-x64 --releaseName "BannerlordModEditor v$Version" --tag $tagName --token $env:GITHUB_TOKEN --releaseNotesFile releasenotes.md
+          vpk upload github -o Releases --repoUrl https://github.com/BannerlordModer/BannerlordModEditor --publish --channel nightly-win-x64 --releaseName "BannerlordModEditor v$Version" --tag $tagName --token $env:GITHUB_TOKEN
           Write-Host "Release uploaded successfully"
         } catch {
           Write-Host "Release upload failed with error: $_"

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -186,7 +186,13 @@ jobs:
           
           # 添加 release notes
           gh release edit $tagName --notes-file releasenotes.md
-          Write-Host "Release notes updated successfully"
+          try {
+            gh release edit $tagName --notes-file releasenotes.md --repo $env:GITHUB_REPOSITORY
+            Write-Host "Release notes updated successfully"
+          } catch {
+            Write-Host "Failed to update release notes: $_"
+            exit 1
+          }
         } catch {
           Write-Host "Release upload failed with error: $_"
           exit 1

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -181,7 +181,7 @@ jobs:
         
         # 上传到 GitHub Releases
         try {
-          vpk upload github --repoUrl https://github.com/BannerlordModer/BannerlordModEditor --publish --channel nightly-win-x64 --releaseName "BannerlordModEditor v$Version" --tag $tagName --token $env:GITHUB_TOKEN --releaseNotesFile releasenotes.md
+          vpk upload github -o Releases --repoUrl https://github.com/BannerlordModer/BannerlordModEditor --publish --channel nightly-win-x64 --releaseName "BannerlordModEditor v$Version" --tag $tagName --token $env:GITHUB_TOKEN --releaseNotesFile releasenotes.md
           Write-Host "Release uploaded successfully"
         } catch {
           Write-Host "Release upload failed with error: $_"


### PR DESCRIPTION
## Summary
- 修复vpk upload github命令参数错误
- 添加release notes支持功能
- 使用两步法：vpk upload + gh release edit

## 修复内容
1. **移除不支持的参数**：vpk upload github不支持--releaseNotesFile参数
2. **添加必需参数**：添加-o Releases参数指定输出目录
3. **两步法发布**：
   - 先用vpk upload github创建release
   - 再用gh release edit添加release notes

## 技术细节
- vpk upload github命令需要-o参数指定输出目录
- 使用gh release edit命令来添加release notes
- 保持完整的release功能同时避免命令参数错误

## 测试计划
- [ ] 等待GitHub Actions自动运行验证
- [ ] 确认发布流程能够正常完成
- [ ] 验证release notes正确显示

🤖 Generated with [Claude Code](https://claude.ai/code)