### PR TITLE
fix: 修复依赖注入配置问题 - 应用程序无法启动

### DIFF
--- a/BannerlordModEditor.UI.Tests/DependencyInjection/DependencyInjectionTests.cs
+++ b/BannerlordModEditor.UI.Tests/DependencyInjection/DependencyInjectionTests.cs
@@ -1,0 +1,79 @@
+using BannerlordModEditor.UI.Services;
+using BannerlordModEditor.UI.Factories;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BannerlordModEditor.UI.Tests.DependencyInjection
+{
+    /// <summary>
+    /// 测试依赖注入配置是否正确
+    /// </summary>
+    public class DependencyInjectionTests
+    {
+        [Fact]
+        public void ConfigureServices_ShouldResolveAllRequiredServices()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // 模拟 App.ConfigureServices() 的配置
+            services.AddSingleton<IEditorFactory, UnifiedEditorFactory>();
+            services.AddSingleton<ILogService, LogService>();
+            services.AddSingleton<IErrorHandlerService, ErrorHandlerService>();
+            services.AddSingleton<IValidationService, ValidationService>();
+            services.AddSingleton<IDataBindingService, DataBindingService>();
+            services.AddTransient<BannerlordModEditor.Common.Services.IFileDiscoveryService, BannerlordModEditor.Common.Services.FileDiscoveryService>();
+            
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act & Assert
+            // 验证 UnifiedEditorFactory 可以被解析
+            var editorFactory = serviceProvider.GetService<IEditorFactory>();
+            Assert.NotNull(editorFactory);
+            Assert.IsType<UnifiedEditorFactory>(editorFactory);
+
+            // 验证所有必需的服务都可以被解析
+            Assert.NotNull(serviceProvider.GetService<ILogService>());
+            Assert.NotNull(serviceProvider.GetService<IErrorHandlerService>());
+            Assert.NotNull(serviceProvider.GetService<IValidationService>());
+            Assert.NotNull(serviceProvider.GetService<IDataBindingService>());
+            Assert.NotNull(serviceProvider.GetService<BannerlordModEditor.Common.Services.IFileDiscoveryService>());
+
+            // 验证 UnifiedEditorFactory 的构造函数参数可以正确注入
+            var unifiedFactory = editorFactory as UnifiedEditorFactory;
+            Assert.NotNull(unifiedFactory);
+        }
+
+        [Fact]
+        public void LogService_ShouldBeSingleton()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddSingleton<ILogService, LogService>();
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act
+            var logService1 = serviceProvider.GetService<ILogService>();
+            var logService2 = serviceProvider.GetService<ILogService>();
+
+            // Assert
+            Assert.Same(logService1, logService2);
+        }
+
+        [Fact]
+        public void ErrorHandlerService_ShouldBeSingleton()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddSingleton<IErrorHandlerService, ErrorHandlerService>();
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Act
+            var errorHandler1 = serviceProvider.GetService<IErrorHandlerService>();
+            var errorHandler2 = serviceProvider.GetService<IErrorHandlerService>();
+
+            // Assert
+            Assert.Same(errorHandler1, errorHandler2);
+        }
+    }
+}

--- a/BannerlordModEditor.UI/App.axaml.cs
+++ b/BannerlordModEditor.UI/App.axaml.cs
@@ -58,6 +58,10 @@ public partial class App : Application
         // 注册编辑器工厂
         services.AddSingleton<IEditorFactory, UnifiedEditorFactory>();
         
+        // 注册日志和错误处理服务
+        services.AddSingleton<ILogService, LogService>();
+        services.AddSingleton<IErrorHandlerService, ErrorHandlerService>();
+        
         // 注册验证和数据绑定服务
         services.AddSingleton<IValidationService, ValidationService>();
         services.AddSingleton<IDataBindingService, DataBindingService>();


### PR DESCRIPTION
## Summary
- 修复了 `UnifiedEditorFactory` 无法解析 `ILogService` 和 `IErrorHandlerService` 的依赖注入问题
- 在 `App.axaml.cs` 的 `ConfigureServices` 方法中添加了缺失的服务注册
- 应用程序现在可以正常启动并显示 Avalonia UI 界面

## Problem
应用程序启动时出现以下错误：
```
System.InvalidOperationException: Unable to resolve service for type 'BannerlordModEditor.UI.Services.ILogService' while attempting to activate 'BannerlordModEditor.UI.Factories.UnifiedEditorFactory'
```

## Root Cause
`UnifiedEditorFactory` 类的构造函数需要以下依赖：
- `ILogService logService`
- `IErrorHandlerService errorHandlerService`

但在 `App.axaml.cs` 的 `ConfigureServices()` 方法中，这两个服务没有被注册到依赖注入容器中。

## Solution
在 `App.axaml.cs` 中添加了缺失的服务注册：
```csharp
// 注册日志和错误处理服务
services.AddSingleton<ILogService, LogService>();
services.AddSingleton<IErrorHandlerService, ErrorHandlerService>();
```

## Test plan
- [x] 应用程序构建成功
- [x] 所有单元测试通过 (185个测试)
- [x] 使用xvfb模拟图形界面验证应用程序正常启动
- [x] 添加依赖注入测试验证配置正确性
- [x] 确认编辑器工厂能够正确创建所有编辑器实例

🤖 Generated with [Claude Code](https://claude.ai/code)